### PR TITLE
multi: change WWW-Authenticate header format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ First, let's request the BOS scores until we hit the freebie limit:
 At some point, we will get an answer 402 with an authorization header:
 
 ```
-www-authenticate: LSAT macaroon='...' invoice='lntb10n1...'
+www-authenticate: LSAT macaroon="...", invoice="lntb10n1..."
 ```
 
 We will need both these values, the `macaroon` and the `invoice` so copy them

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -98,7 +98,7 @@ func (l *LsatAuthenticator) FreshChallengeHeader(r *http.Request,
 		log.Errorf("Error serializing LSAT: %v", err)
 	}
 
-	str := fmt.Sprintf("LSAT macaroon='%s' invoice='%s'",
+	str := fmt.Sprintf("LSAT macaroon=\"%s\", invoice=\"%s\"",
 		base64.StdEncoding.EncodeToString(macBytes), paymentRequest)
 	header := r.Header
 	header.Set("WWW-Authenticate", str)

--- a/auth/mock_authenticator.go
+++ b/auth/mock_authenticator.go
@@ -35,6 +35,13 @@ func (a MockAuthenticator) FreshChallengeHeader(r *http.Request,
 	_ string) (http.Header, error) {
 
 	header := r.Header
-	header.Set("WWW-Authenticate", "LSAT macaroon='AGIAJEemVQUTEyNCR0exk7ek90Cg==' invoice='lnbc1500n1pw5kjhmpp5fu6xhthlt2vucmzkx6c7wtlh2r625r30cyjsfqhu8rsx4xpz5lwqdpa2fjkzep6yptksct5yp5hxgrrv96hx6twvusycn3qv9jx7ur5d9hkugr5dusx6cqzpgxqr23s79ruapxc4j5uskt4htly2salw4drq979d7rcela9wz02elhypmdzmzlnxuknpgfyfm86pntt8vvkvffma5qc9n50h4mvqhngadqy3ngqjcym5a'")
+	header.Set(
+		"WWW-Authenticate", "LSAT macaroon=\"AGIAJEemVQUTEyNCR0exk7ek9"+
+			"0Cg==\", invoice=\"lnbc1500n1pw5kjhmpp5fu6xhthlt2vucm"+
+			"zkx6c7wtlh2r625r30cyjsfqhu8rsx4xpz5lwqdpa2fjkzep6yptk"+
+			"sct5yp5hxgrrv96hx6twvusycn3qv9jx7ur5d9hkugr5dusx6cqzp"+
+			"gxqr23s79ruapxc4j5uskt4htly2salw4drq979d7rcela9wz02el"+
+			"hypmdzmzlnxuknpgfyfm86pntt8vvkvffma5qc9n50h4mvqhngadq"+
+			"y3ngqjcym5a\"")
 	return header, nil
 }

--- a/static/index.html
+++ b/static/index.html
@@ -53,7 +53,7 @@
   let lastInvoice = null;
 
   function parseInvoice(invoice) {
-    const rex = /LSAT macaroon='(.*?)' invoice='(.*?)'/i;
+    const rex = /LSAT macaroon="(.*?)", invoice="(.*?)"/i;
     parts = invoice.match(rex);
     lastMacaroon = parts[1];
     lastInvoice = parts[2];


### PR DESCRIPTION
To be compliant with RFC 7235 section 4.1 we change the format of the
WWW-Authenticate header field to double quoted and comma separated
fields.

Client PR is up as well: https://github.com/lightninglabs/loop/pull/130