### PR TITLE
aperture: check tor config nil-ness before access

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -160,7 +160,7 @@ func start() error {
 	// will only be reached through the onion services, which already
 	// provide encryption, so running this additional HTTP server should be
 	// relatively safe.
-	if cfg.Tor.V2 || cfg.Tor.V3 {
+	if cfg.Tor != nil && (cfg.Tor.V2 || cfg.Tor.V3) {
 		torController, err := initTorListener(cfg, etcdClient)
 		if err != nil {
 			return err


### PR DESCRIPTION
This prevents a panic on startup for instances running with configurations that don't specify any Tor options.