### PR TITLE
config+proxy: disable static file serving by default

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -391,7 +391,9 @@ func createProxy(cfg *config, genInvoiceReq InvoiceRequestGenerator,
 		ServiceLimiter: newStaticServiceLimiter(cfg.Services),
 	})
 	authenticator := auth.NewLsatAuthenticator(minter)
-	return proxy.New(authenticator, cfg.Services, cfg.StaticRoot)
+	return proxy.New(
+		authenticator, cfg.Services, cfg.ServeStatic, cfg.StaticRoot,
+	)
 }
 
 // cleanup closes the given server and shuts down the log rotator.

--- a/config.go
+++ b/config.go
@@ -61,6 +61,10 @@ type config struct {
 	// is located.
 	StaticRoot string `long:"staticroot" description:"The folder where the static content is located."`
 
+	// ServeStatic defines if static content should be served from the
+	// directory defined by StaticRoot.
+	ServeStatic bool `long:"servestatic" description:"Flag to enable or disable static content serving."`
+
 	Etcd *etcdConfig `long:"etcd" description:"Configuration for the etcd instance backing the proxy."`
 
 	Authenticator *authConfig `long:"authenticator" description:"Configuration for the authenticator."`

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -71,7 +71,7 @@ func TestProxyHTTP(t *testing.T) {
 	}}
 
 	mockAuth := auth.NewMockAuthenticator()
-	p, err := proxy.New(mockAuth, services, "static")
+	p, err := proxy.New(mockAuth, services, true, "static")
 	if err != nil {
 		t.Fatalf("failed to create new proxy: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestProxyGRPC(t *testing.T) {
 
 	// Create the proxy server and start serving on TLS.
 	mockAuth := auth.NewMockAuthenticator()
-	p, err := proxy.New(mockAuth, services, "static")
+	p, err := proxy.New(mockAuth, services, true, "static")
 	if err != nil {
 		t.Fatalf("failed to create new proxy: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestWhitelistHTTP(t *testing.T) {
 	}}
 
 	mockAuth := auth.NewMockAuthenticator()
-	p, err := proxy.New(mockAuth, services, "static")
+	p, err := proxy.New(mockAuth, services, true, "static")
 	if err != nil {
 		t.Fatalf("failed to create new proxy: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestWhitelistGRPC(t *testing.T) {
 
 	// Create the proxy server and start serving on TLS.
 	mockAuth := auth.NewMockAuthenticator()
-	p, err := proxy.New(mockAuth, services, "static")
+	p, err := proxy.New(mockAuth, services, true, "static")
 	if err != nil {
 		t.Fatalf("failed to create new proxy: %v", err)
 	}

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -5,6 +5,10 @@ listenaddr: "localhost:8081"
 # cannot handle.
 staticroot: "./static"
 
+# Should the static file server be enabled that serves files from the directory
+# specified in `staticroot`?
+servestatic: false
+
 # The log level that should be used for the proxy.
 #
 # Valid options include: trace, debug, info, warn, error, critical, off.


### PR DESCRIPTION
We don't want to serve static files by default. 