### PR TITLE
challenger: shutdown if connection to lnd is lost

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -110,7 +110,10 @@ func run() error {
 			Value: price,
 		}, nil
 	}
-	challenger, err := NewLndChallenger(cfg.Authenticator, genInvoiceReq)
+	errChan := make(chan error)
+	challenger, err := NewLndChallenger(
+		cfg.Authenticator, genInvoiceReq, errChan,
+	)
 	if err != nil {
 		return err
 	}
@@ -164,7 +167,6 @@ func run() error {
 	)
 	log.Infof("Starting the server, listening on %s.", cfg.ListenAddr)
 
-	errChan := make(chan error)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/challenger.go
+++ b/challenger.go
@@ -49,6 +49,8 @@ type LndChallenger struct {
 	invoicesCancel func()
 	invoicesCond   *sync.Cond
 
+	errChan chan<- error
+
 	quit chan struct{}
 	wg   sync.WaitGroup
 }
@@ -66,8 +68,8 @@ const (
 
 // NewLndChallenger creates a new challenger that uses the given connection
 // details to connect to an lnd backend to create payment challenges.
-func NewLndChallenger(cfg *authConfig, genInvoiceReq InvoiceRequestGenerator) (
-	*LndChallenger, error) {
+func NewLndChallenger(cfg *authConfig, genInvoiceReq InvoiceRequestGenerator,
+	errChan chan<- error) (*LndChallenger, error) {
 
 	if genInvoiceReq == nil {
 		return nil, fmt.Errorf("genInvoiceReq cannot be nil")
@@ -89,6 +91,7 @@ func NewLndChallenger(cfg *authConfig, genInvoiceReq InvoiceRequestGenerator) (
 		invoicesMtx:   invoicesMtx,
 		invoicesCond:  sync.NewCond(invoicesMtx),
 		quit:          make(chan struct{}),
+		errChan:       errChan,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes the issue `Deny: Invoice status mismatch: no active or settled invoice found for hash=5e0...` when aperture loses its connection to lnd. For now we just shut down so an orchestrator can restart it when the connection is available again.