### PR TITLE
maintenance: update lnd dependencies, prepare for production docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker image build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  DOCKER_REPO: lightninglabs
+  DOCKER_IMAGE: aperture
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
+          build-args: checkout=${{ env.RELEASE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/aperture.go
+++ b/aperture.go
@@ -91,6 +91,13 @@ func run() error {
 		return fmt.Errorf("unable to set up logging: %v", err)
 	}
 
+	// Before starting everything, make sure we can intercept any interrupt
+	// signals so we can block on waiting for them later.
+	err = signal.Intercept()
+	if err != nil {
+		return err
+	}
+
 	// Initialize our etcd client.
 	etcdClient, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{cfg.Etcd.Host},
@@ -208,10 +215,6 @@ func run() error {
 			}
 		}()
 	}
-
-	// Now that we've started everything, intercept any interrupt signals
-	// and wait for any of them to arrive.
-	signal.Intercept()
 
 	var returnErr error
 	select {

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/jonboulle/clockwork v0.2.0 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
-	github.com/lightninglabs/lndclient v0.11.0-0
-	github.com/lightningnetwork/lnd v0.11.0-beta
+	github.com/lightninglabs/lndclient v0.11.0-4
+	github.com/lightningnetwork/lnd v0.11.1-beta
 	github.com/lightningnetwork/lnd/cert v1.0.2
 	github.com/stretchr/testify v1.5.1
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200122045848-3419fae592fc // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,12 @@ github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2ut
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/btcutil/psbt v1.0.2 h1:gCVY3KxdoEVU7Q6TjusPO+GANIwVgr9yTLqM+a6CZr8=
 github.com/btcsuite/btcutil/psbt v1.0.2/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
+github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0 h1:3Zumkyl6PWyHuVJ04me0xeD9CnPOhNgeGpapFbzy7O4=
+github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
 github.com/btcsuite/btcwallet v0.11.1-0.20200814001439-1d31f4ea6fc5 h1:1We7EuizBnX/17Q6O2dkeToyehxzUHo62Wv1c0ncr7c=
 github.com/btcsuite/btcwallet v0.11.1-0.20200814001439-1d31f4ea6fc5/go.mod h1:YkEbJaCyN6yncq5gEp2xG0OKDwus2QxGCEXTNF27w5I=
+github.com/btcsuite/btcwallet v0.11.1-0.20200904022754-2c5947a45222 h1:rh1FQAhh+BeR29twIFDM0RLOFpDK62tsABtUkWctTXw=
+github.com/btcsuite/btcwallet v0.11.1-0.20200904022754-2c5947a45222/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=
@@ -190,6 +194,8 @@ github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lndclient v0.11.0-0 h1:tCvhlN/NNC/PeCjifONq/f8vU/6ZJS1ivXhpIfw6JfY=
 github.com/lightninglabs/lndclient v0.11.0-0/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
+github.com/lightninglabs/lndclient v0.11.0-4 h1:g3JVAl/TepiE6TH8xl9aSnrgeQl/msByDhgZ4Kgxl60=
+github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
 github.com/lightninglabs/neutrino v0.11.0 h1:lPpYFCtsfJX2W5zI4pWycPmbbBdr7zU+BafYdLoD6k0=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200 h1:j4iZ1XlUAPQmW6oSzMcJGILYsRHNs+4O3Gk+2Ms5Dww=
@@ -199,6 +205,8 @@ github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
 github.com/lightningnetwork/lnd v0.11.0-beta h1:pUAT7FMHqS+iarNxyRtgj96XKCGAWwmb6ZdiUBy78ts=
 github.com/lightningnetwork/lnd v0.11.0-beta/go.mod h1:CzArvT7NFDLhVyW06+NJWSuWFmE6Ea+AjjA3txUBqTM=
+github.com/lightningnetwork/lnd v0.11.1-beta h1:SYpb8s+to3rAPTd4fWqkhTEO2QpnGJ3MJYb7m09fPjE=
+github.com/lightningnetwork/lnd v0.11.1-beta/go.mod h1:PGIgxy8aH70Li33YVYkHSaCM8m8LjEevk5h1Dpldrr4=
 github.com/lightningnetwork/lnd/cert v1.0.2 h1:g2rEu+sM2Uyz0bpfuvwri/ks6R/26H5iY1NcGbpDJ+c=
 github.com/lightningnetwork/lnd/cert v1.0.2/go.mod h1:fmtemlSMf5t4hsQmcprSoOykypAPp+9c+0d0iqTScMo=
 github.com/lightningnetwork/lnd/clock v1.0.1 h1:QQod8+m3KgqHdvVMV+2DRNNZS1GRFir8mHZYA+Z2hFo=

--- a/internal/test/lightning_client_mock.go
+++ b/internal/test/lightning_client_mock.go
@@ -20,6 +20,7 @@ import (
 )
 
 type mockLightningClient struct {
+	lndclient.LightningClient
 	lnd *LndMockServices
 	wg  sync.WaitGroup
 }
@@ -250,21 +251,22 @@ func (h *mockLightningClient) DecodePaymentRequest(_ context.Context,
 // OpenChannel opens a channel to the peer provided with the amounts
 // specified.
 func (h *mockLightningClient) OpenChannel(_ context.Context, _ route.Vertex,
-	_, _ btcutil.Amount) (*wire.OutPoint, error) {
+	_, _ btcutil.Amount, _ bool) (*wire.OutPoint, error) {
 
 	return nil, nil
 }
 
 // CloseChannel closes the channel provided.
 func (h *mockLightningClient) CloseChannel(_ context.Context, _ *wire.OutPoint,
-	_ bool) (chan lndclient.CloseChannelUpdate, chan error, error) {
+	_ bool, _ int32, _ btcutil.Address) (chan lndclient.CloseChannelUpdate,
+	chan error, error) {
 
 	return nil, nil, nil
 }
 
 // Connect attempts to connect to a peer at the host specified.
 func (h *mockLightningClient) Connect(_ context.Context, _ route.Vertex,
-	_ string) error {
+	_ string, _ bool) error {
 
 	return nil
 }

--- a/internal/test/walletkit_mock.go
+++ b/internal/test/walletkit_mock.go
@@ -17,6 +17,7 @@ import (
 )
 
 type mockWalletKit struct {
+	lndclient.WalletKitClient
 	lnd          *LndMockServices
 	keyIndex     int32
 	feeEstimates map[int32]chainfee.SatPerKWeight
@@ -80,14 +81,16 @@ func (m *mockWalletKit) NextAddr(ctx context.Context) (btcutil.Address, error) {
 	return addr, nil
 }
 
-func (m *mockWalletKit) PublishTransaction(ctx context.Context, tx *wire.MsgTx) error {
+func (m *mockWalletKit) PublishTransaction(_ context.Context, tx *wire.MsgTx,
+	_ string) error {
+
 	m.lnd.AddTx(tx)
 	m.lnd.TxPublishChannel <- tx
 	return nil
 }
 
 func (m *mockWalletKit) SendOutputs(ctx context.Context, outputs []*wire.TxOut,
-	feeRate chainfee.SatPerKWeight) (*wire.MsgTx, error) {
+	feeRate chainfee.SatPerKWeight, _ string) (*wire.MsgTx, error) {
 
 	var inputTxHash chainhash.Hash
 


### PR DESCRIPTION
We update to `lnd v0.11.1-beta` and `lndclient v0.11.0-4` and add a new production `Dockerfile` and a GitHub workflow that is triggered whenever a new version tag is
pushed. It will trigger a docker image build for that version and automatically push it to the specified repo.

For this to work, the GitHub repository needs the following two secrets to be configured:

```
DOCKER_USERNAME: <the user to log into Docker Hub>
DOCKER_API_KEY: <an API key generated by Docker Hub for the above user>
```
