### PR TITLE
Kirin comments renamed to Aperture

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -67,7 +67,7 @@ var (
 	}
 )
 
-// Main is the true entrypoint of Kirin.
+// Main is the true entrypoint of Aperture.
 func Main() {
 	// TODO: Prevent from running twice.
 	err := run()

--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ type torConfig struct {
 }
 
 type config struct {
-	// ListenAddr is the listening address that we should use to allow Kirin
+	// ListenAddr is the listening address that we should use to allow Aperture
 	// to listen for requests.
 	ListenAddr string `long:"listenaddr" description:"The interface we should listen on for client requests."`
 
@@ -72,10 +72,10 @@ type config struct {
 	Tor *torConfig `long:"tor" description:"Configuration for the Tor instance backing the proxy."`
 
 	// Services is a list of JSON objects in string format, which specify
-	// each backend service to Kirin.
-	Services []*proxy.Service `long:"service" description:"Configurations for each Kirin backend service."`
+	// each backend service to Aperture.
+	Services []*proxy.Service `long:"service" description:"Configurations for each Aperture backend service."`
 
 	// DebugLevel is a string defining the log level for the service either
 	// for all subsystems the same or individual level by subsystem.
-	DebugLevel string `long:"debuglevel" description:"Debug level for the Kirin application and its subsystems."`
+	DebugLevel string `long:"debuglevel" description:"Debug level for the Aperture application and its subsystems."`
 }

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -31,7 +31,7 @@ const (
 )
 
 // Service generically specifies configuration data for backend services to the
-// Kirin proxy.
+// Aperture proxy.
 type Service struct {
 	// Name is the name of the LSAT-enabled service.
 	Name string `long:"name" description:"Name of the LSAT-enabled service"`


### PR DESCRIPTION
When starting to study how the code works I've just stumbled across a few instances of Kirin (which according to 0c14706fa4e8c4903e0b7d6ba79de3a5324c65b9 is the old name). Trivial search & replace (with sed) to move everything to Aperture. Hopefully after I get a better understanding of this I can contribute something more useful too.