### PR TITLE
Be able to run aperture without etcd

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,11 +34,17 @@ type authConfig struct {
 }
 
 type torConfig struct {
+	FileStorage bool   `long:"filestorage" description:"Use file based storage for private keys."`
 	Control     string `long:"control" description:"The host:port of the Tor instance."`
 	ListenPort  uint16 `long:"listenport" description:"The port we should listen on for client requests over Tor. Note that this port should not be exposed to the outside world, it is only intended to be reached by clients through the onion service."`
 	VirtualPort uint16 `long:"virtualport" description:"The port through which the onion services created can be reached at."`
 	V2          bool   `long:"v2" description:"Whether we should listen for client requests through a v2 onion service."`
 	V3          bool   `long:"v3" description:"Whether we should listen for client requests through a v3 onion service."`
+}
+
+type staticSecret struct {
+	Seed    string `long:"seed" description:"A seed for generating pseudo-random values (should be as unpredictable as possible)."`
+	Enabled bool   `long:"enabled" description:"When true use pseudo-random secrets derived from seed."`
 }
 
 type config struct {
@@ -66,6 +72,9 @@ type config struct {
 	ServeStatic bool `long:"servestatic" description:"Flag to enable or disable static content serving."`
 
 	Etcd *etcdConfig `long:"etcd" description:"Configuration for the etcd instance backing the proxy."`
+
+	// Static secrets to enable pseudo-randomness (optional).
+	StaticSecret *staticSecret `long:"staticsecret" description:"Configuration for pseudo-random secrets."`
 
 	Authenticator *authConfig `long:"authenticator" description:"Configuration for the authenticator."`
 

--- a/onion_store_file.go
+++ b/onion_store_file.go
@@ -1,0 +1,81 @@
+package aperture
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/lightningnetwork/lnd/tor"
+)
+
+// onionStoreFile is an file-based implementation of tor.OnionStore.
+type onionStoreFile struct {
+	rootDir string
+}
+
+// A compile-time constraint to ensure onionStore implements tor.OnionStore.
+var _ tor.OnionStore = (*onionStoreFile)(nil)
+
+// newOnionStoreFile creates an file-based implementation of tor.OnionStore.
+func newOnionStoreFile(rootDir string) *onionStoreFile {
+	return &onionStoreFile{rootDir: rootDir}
+}
+
+// onionFilePath returns the absolute filesystem path to an onion service's private key of the
+// given type.
+func (s *onionStoreFile) onionFilePath(onionType tor.OnionType) (string, error) {
+	var typeName string
+	switch onionType {
+	case tor.V2:
+		typeName = "v2"
+	case tor.V3:
+		typeName = "v3"
+	default:
+		return "", fmt.Errorf("unknown onion type %v", onionType)
+	}
+
+	return filepath.Join(s.rootDir, fmt.Sprintf("onion-%s.key", typeName)), nil
+}
+
+// StorePrivateKey stores the given private key.
+func (s *onionStoreFile) StorePrivateKey(onionType tor.OnionType,
+	privateKey []byte) error {
+
+	name, err := s.onionFilePath(onionType)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(name, privateKey, 0400)
+}
+
+// PrivateKey retrieves a stored private key. If it is not found, then
+// ErrNoPrivateKey should be returned.
+func (s *onionStoreFile) PrivateKey(onionType tor.OnionType) ([]byte, error) {
+	name, err := s.onionFilePath(onionType)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadFile(name)
+	if err != nil && os.IsNotExist(err) {
+		return nil, tor.ErrNoPrivateKey
+	}
+
+	return data, err
+}
+
+// DeletePrivateKey securely removes the private key from the store.
+func (s *onionStoreFile) DeletePrivateKey(onionType tor.OnionType) error {
+	name, err := s.onionFilePath(onionType)
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(name)
+	if err != nil && os.IsNotExist(err) {
+		return tor.ErrNoPrivateKey
+	}
+
+	return err
+}

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -97,6 +97,9 @@ services:
 # Settings for a Tor instance to allow requests over Tor as onion services.
 # Configuring Tor is optional.
 tor:
+  # By default etcd is used for storing private keys, if you want to use the simple file-backed storage, turn this on.
+  filestorage: false
+
   # The host:port which Tor's control can be reached at.
   control: "localhost:9051"
 
@@ -113,3 +116,13 @@ tor:
 
   # Whether a v3 onion service should be created to handle requests.
   v3: false
+
+# Experimental: use this for generating pseudo-random values.
+# Currently used only for LSAT macaroons.
+# Pros:
+#   - no need for etcd
+# Cons:
+#   - potentially unsafe and buggy
+staticsecret:
+    seed: "something_very_unpredictable_comes_here!@#"
+    enabled: false


### PR DESCRIPTION
As promised in https://github.com/lightninglabs/aperture/pull/49 my wish is to contribute something more useful here too. I understand this will probably need more discussion, just to see whether my idea is sane. Golang is not my native language, so I am of course also open to suggestions in that direction.

Etcd is quite useful and lightweight, but I want to be able to run aperture w/o that dependency.

This is done through:
- add simple file-backed storage for onion keys
- be able to use pseudo-random secrets for LSAT macaroons
(unpredictable seed from config file and random TokenID is used for
that in a HMAC construction. Macaroons are HMACs all the way down
anyways ;) )