### PR TITLE
proxy: remove manual trailer fields

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -333,10 +333,6 @@ func sendDirectResponse(w http.ResponseWriter, r *http.Request,
 	case strings.HasPrefix(r.Header.Get(hdrContentType), hdrTypeGrpc):
 		w.Header().Set(hdrGrpcStatus, strconv.Itoa(int(codes.Internal)))
 		w.Header().Set(hdrGrpcMessage, errInfo)
-		w.Header().Set("Content-Length", "0")
-		w.Header().Set(":status", strconv.Itoa(statusCode))
-		w.Header().Add("Trailer", hdrGrpcStatus)
-		w.Header().Add("Trailer", hdrGrpcMessage)
 
 		w.WriteHeader(statusCode)
 


### PR DESCRIPTION
The last bugfix (#52) added some explicit header fields in an attempt of
fixing an issue with error responses. Unfortunately they weren't
strictly needed for the fix but ended up causing issues in a non-error
case.
This commit removes those header fields again and makes sure the "auth
header not found in response" header doesn't occur anymore.