### PR TITLE
multi: add base dir to aperture

### DIFF
--- a/config.go
+++ b/config.go
@@ -107,6 +107,9 @@ type Config struct {
 
 	// ConfigFile points aperture to an alternative config file.
 	ConfigFile string `long:"configfile" description:"Custom path to a config file."`
+
+	// BaseDir is a custom directory to store all aperture flies.
+	BaseDir string `long:"basedir" description:"Directory to place all of aperture's files in."`
 }
 
 func (c *Config) validate() error {


### PR DESCRIPTION
This PR adds a base dir to aperture for move convenient file placement. 

There's always some thinking to so with our various file placement flags (specifically `--configfile` and `--basedir`), gone with the following logic: 
* Default to `AppDir` if nothing is set
* If only `--configfile` is set, use `AppDir` for files, use custom config location and require that it exists
* If only `--basedir` is set, look for `aperture.yaml` in `basedir` but do not require it
* If `--configfile` and `--basedir` are set, use `basedir` for files and require `--configfile` exists

Reason for allowing a `--configfile` and `--basedir` is that custom config file allows you to set the name of your config file as well as location.