### PR TITLE
config: add group and namespace to hashmail config

### DIFF
--- a/config.go
+++ b/config.go
@@ -114,7 +114,7 @@ type Config struct {
 
 	// HashMail is the configuration section for configuring the Lightning
 	// Node Connect mailbox server.
-	HashMail *HashMailConfig `long:"hashmail" description:"Configuration for the Lightning Node Connect mailbox server."`
+	HashMail *HashMailConfig `group:"hashmail" namespace:"hashmail" description:"Configuration for the Lightning Node Connect mailbox server."`
 
 	// DebugLevel is a string defining the log level for the service either
 	// for all subsystems the same or individual level by subsystem.


### PR DESCRIPTION
Add group and namespace to hashmail config so that hashmail params can
be specified on the command line.