### PR TITLE
multi: mailbox metrics

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -710,6 +710,9 @@ func createHashMailServer(cfg *Config) ([]proxy.LocalService, func(), error) {
 		}),
 	)
 
+	// Export the gRPC information for the public gRPC server.
+	grpc_prometheus.Register(hashMailGRPC)
+
 	// And a REST proxy for it as well.
 	// The default JSON marshaler of the REST proxy only sets OrigName to
 	// true, which instructs it to use the same field names as specified in

--- a/config.go
+++ b/config.go
@@ -64,10 +64,6 @@ type HashMailConfig struct {
 	Enabled               bool          `long:"enabled"`
 	MessageRate           time.Duration `long:"messagerate" description:"The average minimum time that should pass between each message."`
 	MessageBurstAllowance int           `long:"messageburstallowance" description:"The burst rate we allow for messages."`
-
-	// PromListenAddr is the listening address that we should use to allow
-	// the main Prometheus server to scrape our metrics.
-	PromListenAddr string `long:"promlistenaddr" description:"the interface we should listen on for prometheus"`
 }
 
 type TorConfig struct {
@@ -115,6 +111,10 @@ type Config struct {
 	// HashMail is the configuration section for configuring the Lightning
 	// Node Connect mailbox server.
 	HashMail *HashMailConfig `group:"hashmail" namespace:"hashmail" description:"Configuration for the Lightning Node Connect mailbox server."`
+
+	// Prometheus is the config for setting up an endpoint for a Prometheus
+	// server to scrape metrics from.
+	Prometheus *PrometheusConfig `group:"prometheus" namespace:"prometheus" description:"Configuration setting up an endpoint that a Prometheus server can scrape."`
 
 	// DebugLevel is a string defining the log level for the service either
 	// for all subsystems the same or individual level by subsystem.

--- a/hashmail_server.go
+++ b/hashmail_server.go
@@ -406,6 +406,8 @@ func (h *hashMailServer) InitStream(
 
 	h.streams[streamID] = freshStream
 
+	mailboxCount.Set(float64(len(h.streams)))
+
 	return &hashmailrpc.CipherInitResp{
 		Resp: &hashmailrpc.CipherInitResp_Success{},
 	}, nil
@@ -477,6 +479,8 @@ func (h *hashMailServer) TearDownStream(ctx context.Context, streamID []byte,
 	}
 
 	delete(h.streams, sid)
+
+	mailboxCount.Set(float64(len(h.streams)))
 
 	return nil
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -4,7 +4,16 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	// mailboxCount tracks the current number of active mailboxes.
+	mailboxCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "hashmail",
+		Name:      "mailbox_count",
+	})
 )
 
 // PrometheusConfig is the set of configuration data that specifies if
@@ -29,6 +38,7 @@ func StartPrometheusExporter(cfg *PrometheusConfig) error {
 	}
 
 	// Next, we'll register all our metrics.
+	prometheus.MustRegister(mailboxCount)
 
 	// Finally, we'll launch the HTTP server that Prometheus will use to
 	// scape our metrics.

--- a/prometheus.go
+++ b/prometheus.go
@@ -1,0 +1,44 @@
+package aperture
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// PrometheusConfig is the set of configuration data that specifies if
+// Prometheus metric exporting is activated, and if so the listening address of
+// the Prometheus server.
+type PrometheusConfig struct {
+	// Enabled, if true, then Prometheus metrics will be exported.
+	Enabled bool `long:"enabled" description:"if true prometheus metrics will be exported"`
+
+	// ListenAddr is the listening address that we should use to allow the
+	// main Prometheus server to scrape our metrics.
+	ListenAddr string `long:"listenaddr" description:"the interface we should listen on for prometheus"`
+}
+
+// StartPrometheusExporter registers all relevant metrics with the Prometheus
+// library, then launches the HTTP server that Prometheus will hit to scrape
+// our metrics.
+func StartPrometheusExporter(cfg *PrometheusConfig) error {
+	// If we're not active, then there's nothing more to do.
+	if !cfg.Enabled {
+		return nil
+	}
+
+	// Next, we'll register all our metrics.
+
+	// Finally, we'll launch the HTTP server that Prometheus will use to
+	// scape our metrics.
+	go func() {
+		log.Infof("Prometheus metrics http endpoint being served on "+
+			"%s", cfg.ListenAddr)
+
+		http.Handle("/metrics", promhttp.Handler())
+		fmt.Println(http.ListenAndServe(cfg.ListenAddr, nil))
+	}()
+
+	return nil
+}

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -151,3 +151,9 @@ hashmail:
   enabled: true
   messagerate: 20ms
   messageburstallowance: 1000
+
+# Enable the prometheus metrics exporter so that a prometheus server can scrape
+# the metrics.
+prometheus:
+  enabled: true
+  listenaddr: "localhost:9000"


### PR DESCRIPTION
Extract prometheus config so that it can be used more generally & get metrics for number of active mailboxes