### PR TITLE
multi: add mailbox read counter

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -8,12 +8,28 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const streamIDLabel = "streamID"
+
 var (
 	// mailboxCount tracks the current number of active mailboxes.
 	mailboxCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "hashmail",
 		Name:      "mailbox_count",
 	})
+
+	// mailboxReadCount counts each time a mailbox pair is being used.
+	// A session consists of a bidirectional stream each using a mailbox
+	// with an ID that overlaps for the first 63 bytes and differ for the
+	// last bit. So in order to obtain accurate data about a specific
+	// mailbox session, the stream ID that will be recorded is the first
+	// 16 bytes of the session ID and we will only record the odd stream's
+	// reads so that we don't duplicate the data.
+	mailboxReadCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hashmail",
+			Name:      "mailbox_read_count",
+		}, []string{streamIDLabel},
+	)
 )
 
 // PrometheusConfig is the set of configuration data that specifies if
@@ -39,6 +55,7 @@ func StartPrometheusExporter(cfg *PrometheusConfig) error {
 
 	// Next, we'll register all our metrics.
 	prometheus.MustRegister(mailboxCount)
+	prometheus.MustRegister(mailboxReadCount)
 
 	// Finally, we'll launch the HTTP server that Prometheus will use to
 	// scape our metrics.


### PR DESCRIPTION
In this commit, we add a mailbox-read-count metric. This will be
incremented each time a mailbox with an _odd_ stream ID is read from.
We do this because we assume that a full duplex connection is being used
meaning that there will be 2 streams that have a matching ID except for
the last byte. And so to avoid duplicating the data, we only record the
odd streams. We also assume that for every read, there will be a write
and so we only record the reads.