### PR TITLE
multi: profile server

### DIFF
--- a/config.go
+++ b/config.go
@@ -125,6 +125,9 @@ type Config struct {
 
 	// BaseDir is a custom directory to store all aperture flies.
 	BaseDir string `long:"basedir" description:"Directory to place all of aperture's files in."`
+
+	// ProfilePort is the port on which the pprof profile will be served.
+	ProfilePort uint16 `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65535"`
 }
 
 func (c *Config) validate() error {

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -19,6 +19,10 @@ debuglevel: "debug"
 autocert: false
 servername: aperture.example.com
 
+# The port on which the pprof profile will be served. If no port is provided,
+# the profile will not be served.
+profile: 9999
+
 # Settings for the lnd node used to generate payment requests. All of these
 # options are required.
 authenticator:


### PR DESCRIPTION
This commit adds a config option that can be set in order to spin up a
pprof profile server on the given port.