### PR TITLE
Timeout Caveat Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 /aperture
 cmd/aperture/aperture
+
+# misc
+.vscode

--- a/aperture.go
+++ b/aperture.go
@@ -662,6 +662,7 @@ func createProxy(cfg *Config, challenger *LndChallenger,
 		Challenger:     challenger,
 		Secrets:        newSecretStore(etcdClient),
 		ServiceLimiter: newStaticServiceLimiter(cfg.Services),
+		Now:            time.Now,
 	})
 	authenticator := auth.NewLsatAuthenticator(minter, challenger)
 

--- a/lsat/satisfier_test.go
+++ b/lsat/satisfier_test.go
@@ -1,0 +1,87 @@
+package lsat
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTimeoutSatisfier tests that the Timeout Satisfier implementation behaves
+// as expected and correctly accepts or rejects calls based on if the
+// timeout has been reached or not.
+func TestTimeoutSatisfier(t *testing.T) {
+	t.Parallel()
+
+	now := int64(0)
+
+	var tests = []struct {
+		name           string
+		timeouts       []int64
+		expectFinalErr bool
+		expectPrevErr  bool
+	}{
+		{
+			name:     "current time is before expiration",
+			timeouts: []int64{now + 1000},
+		},
+		{
+			name: "time passed is greater than " +
+				"expiration",
+			timeouts:       []int64{now - 1000},
+			expectFinalErr: true,
+		},
+		{
+			name: "successive caveats are increasingly " +
+				"restrictive and not yet expired",
+			timeouts: []int64{now + 1000, now + 500},
+		},
+		{
+			name: "latter caveat is less restrictive " +
+				"then previous",
+			timeouts:      []int64{now + 500, now + 1000},
+			expectPrevErr: true,
+		},
+	}
+
+	var (
+		service   = "restricted"
+		condition = service + CondTimeoutSuffix
+		satisfier = NewTimeoutSatisfier(service, func() time.Time {
+			return time.Unix(now, 0)
+		})
+	)
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			var prev *Caveat
+			for _, timeout := range test.timeouts {
+				caveat := NewCaveat(
+					condition, fmt.Sprintf("%d", timeout),
+				)
+
+				if prev != nil {
+					err := satisfier.SatisfyPrevious(
+						*prev, caveat,
+					)
+					if test.expectPrevErr {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+					}
+				}
+
+				err := satisfier.SatisfyFinal(caveat)
+				if test.expectFinalErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+
+				prev = &caveat
+			}
+		})
+	}
+}

--- a/lsat/service.go
+++ b/lsat/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -15,6 +16,10 @@ const (
 	// capabilities caveat. For example, the condition of a capabilities
 	// caveat for a service named `loop` would be `loop_capabilities`.
 	CondCapabilitiesSuffix = "_capabilities"
+
+	// CondTimeoutSuffix is the condition suffix used for a service's
+	// timeout caveat.
+	CondTimeoutSuffix = "_valid_until"
 )
 
 var (
@@ -127,5 +132,21 @@ func NewCapabilitiesCaveat(serviceName string, capabilities string) Caveat {
 	return Caveat{
 		Condition: serviceName + CondCapabilitiesSuffix,
 		Value:     capabilities,
+	}
+}
+
+// NewTimeoutCaveat creates a new caveat that will result in a macaroon being
+// valid for numSeconds after the current time.
+func NewTimeoutCaveat(serviceName string, numSeconds int64,
+	now func() time.Time) Caveat {
+
+	var (
+		macaroonTimeout = time.Duration(numSeconds) * time.Second
+		requestTimeout  = now().Add(macaroonTimeout)
+	)
+
+	return Caveat{
+		Condition: serviceName + CondTimeoutSuffix,
+		Value:     strconv.FormatInt(requestTimeout.Unix(), 10),
 	}
 }

--- a/mint/mock_test.go
+++ b/mint/mock_test.go
@@ -73,6 +73,7 @@ func newMockSecretStore() *mockSecretStore {
 type mockServiceLimiter struct {
 	capabilities map[lsat.Service]lsat.Caveat
 	constraints  map[lsat.Service][]lsat.Caveat
+	timeouts     map[lsat.Service]lsat.Caveat
 }
 
 var _ ServiceLimiter = (*mockServiceLimiter)(nil)
@@ -81,6 +82,7 @@ func newMockServiceLimiter() *mockServiceLimiter {
 	return &mockServiceLimiter{
 		capabilities: make(map[lsat.Service]lsat.Caveat),
 		constraints:  make(map[lsat.Service][]lsat.Caveat),
+		timeouts:     make(map[lsat.Service]lsat.Caveat),
 	}
 }
 
@@ -108,6 +110,20 @@ func (l *mockServiceLimiter) ServiceConstraints(ctx context.Context,
 			continue
 		}
 		res = append(res, constraints...)
+	}
+	return res, nil
+}
+
+func (l *mockServiceLimiter) ServiceTimeouts(ctx context.Context,
+	services ...lsat.Service) ([]lsat.Caveat, error) {
+
+	res := make([]lsat.Caveat, 0, len(services))
+	for _, service := range services {
+		timeouts, ok := l.timeouts[service]
+		if !ok {
+			continue
+		}
+		res = append(res, timeouts)
 	}
 	return res, nil
 }

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -72,6 +72,12 @@ type Service struct {
 	// the file is sent encoded as base64.
 	Headers map[string]string `long:"headers" description:"Header fields to always pass to the service"`
 
+	// Timeout is an optional value that indicates in how many seconds the
+	// service's caveat should time out relative to the time of creation. So
+	// if a value of 100 is set, then the timeout will be 100 seconds
+	// after creation of the LSAT.
+	Timeout int64 `long:"timeout" description:"An integer value that indicates the number of seconds until the service access expires"`
+
 	// Capabilities is the list of capabilities authorized for the service
 	// at the base tier.
 	Capabilities string `long:"capabilities" description:"A comma-separated list of the service capabilities authorized for the base tier"`

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -84,7 +84,13 @@ services:
     # The set of constraints that are applied to tokens of the service at the
     # base tier.
     constraints:
-        "valid_until": "2020-01-01"
+        # This is just an example of how aperture could be extended
+        # but would not have any effect without additional support added.
+        "valid_until": 1682483169
+      
+    # a caveat will be added that expires the LSAT after this many seconds,
+    # 31557600 = 1 year.
+    timeout: 31557600    
 
     # The LSAT value in satoshis for the service. It is ignored if
     # dynamicprice.enabled is set to true.


### PR DESCRIPTION
This is a proof of concept to address #80. It is loosely inspired by `macaroontimeout` and [`TimeoutConstraint`](https://github.com/lightningnetwork/lnd/blob/28ea2736a04566b06c38533e5e48e1b8d185a49b/macaroons/constraints.go#L74-L81) in lnd. 

The way the api for this is supposed to work is that if you want your minted lsats to have an "expiration" for specific services, you set a timeout property in your aperture config at the service level (same as `capabilities` and `constraints`). This should be a value that equates to the number of seconds after minting that the lsat should expire. When the lsat is minted, this value will be consumed and the unix timestamp for that number of seconds from that moment will be added as the value for a caveat with the condition `[service_name]_timeout`.

I've tested this out in an application I'm working on for which this is a feature requirement. If this isn't the preferred approach, I'd be happy to collaborate to find one that works or do what needs to be done to make this an official part of aperture.