### PR TITLE
multi: gc stale mailboxes

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -729,6 +729,7 @@ func createHashMailServer(cfg *Config) ([]proxy.LocalService, func(), error) {
 	hashMailServer := newHashMailServer(hashMailServerConfig{
 		msgRate:           cfg.HashMail.MessageRate,
 		msgBurstAllowance: cfg.HashMail.MessageBurstAllowance,
+		staleTimeout:      cfg.HashMail.StaleTimeout,
 	})
 	hashMailGRPC := grpc.NewServer(serverOpts...)
 	hashmailrpc.RegisterHashMailServer(hashMailGRPC, hashMailServer)

--- a/config.go
+++ b/config.go
@@ -64,6 +64,7 @@ type HashMailConfig struct {
 	Enabled               bool          `long:"enabled"`
 	MessageRate           time.Duration `long:"messagerate" description:"The average minimum time that should pass between each message."`
 	MessageBurstAllowance int           `long:"messageburstallowance" description:"The burst rate we allow for messages."`
+	StaleTimeout          time.Duration `long:"staletimeout" description:"The time after the last activity that a mailbox should be removed. Set to -1s to disable. "`
 }
 
 type TorConfig struct {

--- a/hashmail_server_test.go
+++ b/hashmail_server_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -13,8 +14,10 @@ import (
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/signal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 var (
@@ -241,4 +244,264 @@ func readMsgFromStream(t *testing.T,
 	case box := <-resultChan:
 		return box, nil
 	}
+}
+
+type statusState struct {
+	readOccupied  bool
+	writeOccupied bool
+}
+
+// TestStaleMailboxCleanup tests that the streamStatus behaves as expected and
+// that it correctly tears down a mailbox if it becomes stale.
+func TestStaleMailboxCleanup(t *testing.T) {
+	tests := []struct {
+		name                      string
+		staleTimeout              time.Duration
+		senderConnected           statusState
+		readerConnected           statusState
+		senderDisconnected        statusState
+		expectStaleMailboxRemoval bool
+	}{
+		{
+			name:         "tear down stale mailbox",
+			staleTimeout: 500 * time.Millisecond,
+			senderConnected: statusState{
+				writeOccupied: true,
+			},
+			readerConnected: statusState{
+				writeOccupied: true,
+				readOccupied:  true,
+			},
+			senderDisconnected: statusState{
+				writeOccupied: false,
+				readOccupied:  true,
+			},
+			expectStaleMailboxRemoval: true,
+		},
+		{
+			name:         "dont tear down stale mailbox",
+			staleTimeout: -1,
+			senderConnected: statusState{
+				writeOccupied: false,
+				readOccupied:  false,
+			},
+			readerConnected: statusState{
+				writeOccupied: false,
+				readOccupied:  false,
+			},
+			senderDisconnected: statusState{
+				writeOccupied: false,
+				readOccupied:  false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Set up a new hashmail server.
+			hm := newHashMailHarness(t, hashMailServerConfig{
+				staleTimeout: test.staleTimeout,
+			})
+
+			// Create two clients of the hashmail server.
+			conn1 := hm.newClientConn()
+			conn2 := hm.newClientConn()
+
+			client1 := hashmailrpc.NewHashMailClient(conn1)
+			client2 := hashmailrpc.NewHashMailClient(conn2)
+
+			// Let client 1 create a mailbox on the server.
+			resp, err := client1.NewCipherBox(
+				ctx, &hashmailrpc.CipherBoxAuth{
+					Auth: &hashmailrpc.CipherBoxAuth_LndAuth{},
+					Desc: testStreamDesc,
+				},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, resp.GetSuccess())
+
+			// Assert that neither of the mailbox streams are
+			// occupied to start with.
+			hm.assertStreamsOccupied(statusState{
+				readOccupied:  false,
+				writeOccupied: false,
+			})
+
+			// Let client 1 take the send-stream and write to it.
+			err = sendToStream(client1)
+			require.NoError(t, err)
+
+			hm.assertStreamsOccupied(test.senderConnected)
+
+			// Let client 2 take the read stream and receive from
+			// it.
+			err = recvFromStream(client2)
+			require.NoError(t, err)
+
+			hm.assertStreamsOccupied(test.readerConnected)
+
+			// Ensure that attempting to take the read stream and
+			// receive from it while it is currently occupied will
+			// result in an error.
+			err = recvFromStream(client2)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "read stream occupied")
+
+			hm.assertStreamsOccupied(test.readerConnected)
+
+			// Disconnect client 1. This should release the
+			// send-stream.
+			require.NoError(t, conn1.Close())
+			hm.assertStreamsOccupied(test.senderDisconnected)
+
+			// Disconnect client 1. This should release the
+			// read-stream.
+			require.NoError(t, conn2.Close())
+
+			// Assert that neither of the streams are occupied.
+			hm.assertStreamsOccupied(statusState{
+				readOccupied:  false,
+				writeOccupied: false,
+			})
+
+			// Assert that the stream is torn down.
+			hm.assertStreamExists(!test.expectStaleMailboxRemoval)
+		})
+	}
+}
+
+// hashMailHarness is a test harness that spins up a hashmail server for
+// testing purposes.
+type hashMailHarness struct {
+	t      *testing.T
+	server *hashMailServer
+	lis    *bufconn.Listener
+}
+
+// newHashMailHarness spins up a new hashmail server and serves it on a bufconn
+// listener.
+func newHashMailHarness(t *testing.T,
+	cfg hashMailServerConfig) *hashMailHarness {
+
+	hm := newHashMailServer(cfg)
+
+	lis := bufconn.Listen(1024 * 1024)
+	hashMailGRPC := grpc.NewServer()
+	t.Cleanup(hashMailGRPC.Stop)
+
+	hashmailrpc.RegisterHashMailServer(hashMailGRPC, hm)
+	go func() {
+		require.NoError(t, hashMailGRPC.Serve(lis))
+	}()
+
+	return &hashMailHarness{
+		t:      t,
+		server: hm,
+		lis:    lis,
+	}
+}
+
+// newClientConn creates a new client of the hashMailHarness server.
+func (h *hashMailHarness) newClientConn() *grpc.ClientConn {
+	conn, err := grpc.Dial("bufnet", grpc.WithContextDialer(
+		func(ctx context.Context, s string) (net.Conn, error) {
+			return h.lis.Dial()
+		}), grpc.WithInsecure(),
+	)
+	require.NoError(h.t, err)
+	h.t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	return conn
+}
+
+// assertStreamOccupied checks that the current state of the stream's read and
+// writes streams are the same as the expected state.
+func (h *hashMailHarness) assertStreamsOccupied(state statusState) {
+	err := wait.Predicate(func() bool {
+		h.server.Lock()
+		defer h.server.Unlock()
+
+		stream, ok := h.server.streams[testSID]
+		if !ok {
+			return false
+		}
+
+		stream.status.Lock()
+		defer stream.status.Unlock()
+
+		if stream.status.readStreamOccupied != state.readOccupied {
+			return false
+		}
+
+		return stream.status.writeStreamOccupied == state.writeOccupied
+
+	}, time.Second)
+	require.NoError(h.t, err)
+}
+
+// assertStreamExists ensures that the test stream does or does not exist
+// depending on the value of the boolean passed in.
+func (h *hashMailHarness) assertStreamExists(exists bool) {
+	err := wait.Predicate(func() bool {
+		h.server.Lock()
+		defer h.server.Unlock()
+
+		_, ok := h.server.streams[testSID]
+		return ok == exists
+
+	}, time.Second)
+	require.NoError(h.t, err)
+}
+
+// sendToStream is a helper function that attempts to send dummy data to the
+// test stream using the given client.
+func sendToStream(client hashmailrpc.HashMailClient) error {
+	writeStream, err := client.SendStream(context.Background())
+	if err != nil {
+		return err
+	}
+
+	return writeStream.Send(&hashmailrpc.CipherBox{
+		Desc: testStreamDesc,
+		Msg:  testMessage,
+	})
+}
+
+// recvFromStream is a helper function that attempts to receive dummy data from
+// the test stream using the given client.
+func recvFromStream(client hashmailrpc.HashMailClient) error {
+	readStream, err := client.RecvStream(
+		context.Background(), testStreamDesc,
+	)
+	if err != nil {
+		return err
+	}
+
+	recvChan := make(chan *hashmailrpc.CipherBox)
+	errChan := make(chan error)
+	go func() {
+		box, err := readStream.Recv()
+		if err != nil {
+			errChan <- err
+		}
+		recvChan <- box
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		return fmt.Errorf("timed out waiting to receive from receive " +
+			"stream")
+
+	case err := <-errChan:
+		return err
+
+	case <-recvChan:
+	}
+
+	return nil
 }


### PR DESCRIPTION
In this commit, we start a timer if a mailbox stream is completely 
un-occupied (neither read or write stream is occupied). The timer 
is stopped if either of the streams are occupied and is reset if 
both streams are unoccupied. If the timer ever ticks then the 
mailbox stream is torn down. The default "stale time" is set to one 
hour but this can be set via the `hashmail.staletimeout` flag. 