### PR TITLE
challenger+config: fix bugs related to config parsing and AMP invoice handling 

### DIFF
--- a/challenger/lnd.go
+++ b/challenger/lnd.go
@@ -102,6 +102,12 @@ func (l *LndChallenger) Start() error {
 	// updates for new invoices and/or newly settled invoices.
 	l.invoicesMtx.Lock()
 	for _, invoice := range invoiceResp.Invoices {
+		// Some invoices like AMP invoices may not have a payment hash
+		// populated.
+		if invoice.RHash == nil {
+			continue
+		}
+
 		if invoice.AddIndex > addIndex {
 			addIndex = invoice.AddIndex
 		}
@@ -205,6 +211,12 @@ func (l *LndChallenger) readInvoiceStream(
 			return
 
 		default:
+		}
+
+		// Some invoices like AMP invoices may not have a payment hash
+		// populated.
+		if invoice.RHash == nil {
+			continue
 		}
 
 		hash, err := lntypes.MakeHash(invoice.RHash)

--- a/config.go
+++ b/config.go
@@ -161,7 +161,7 @@ type Config struct {
 	ServeStatic bool `long:"servestatic" description:"Flag to enable or disable static content serving."`
 
 	// DatabaseBackend is the database backend to be used by the server.
-	DatabaseBackend string `long:"dbbackend" description:"The database backend to use for storing all asset related data." choice:"sqlite" choice:"postgres"`
+	DatabaseBackend string `long:"dbbackend" description:"The database backend to use for storing all asset related data." choice:"sqlite" choice:"postgres" yaml:"dbbackend"`
 
 	// Sqlite is the configuration section for the SQLite database backend.
 	Sqlite *aperturedb.SqliteConfig `group:"sqlite" namespace:"sqlite"`


### PR DESCRIPTION
In this PR, we fix to disticnt bugs:
  1. AMP invoices dont' have a payment hash, so if you connect to a node that has one, then some belt-and-suspenders parsing will fail. 
  2. For the yaml parser, since the public attribute differs from the name of the yaml field, we need to specify the `yaml` flag.
     * Without this fix, the new backend can't be specified in the config file, only the command line args. 