### PR TITLE
multi: allow LNC reconnects without restarting the proxy

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -335,8 +335,18 @@ func (a *Aperture) Start(errChan chan error) error {
 					"session: %w", err)
 			}
 
+			// An LNC session will automatically try to reconnect to
+			// the node whenever an error occurs. Instead of
+			// shutting the proxy down we will just log the error.
+			lncErrChan := make(chan error)
+			go func() {
+				for err := range lncErrChan {
+					log.Errorf("lnc session error: %v", err)
+				}
+			}()
+
 			a.challenger, err = challenger.NewLNCChallenger(
-				session, lncStore, genInvoiceReq, errChan,
+				session, lncStore, genInvoiceReq, lncErrChan,
 			)
 			if err != nil {
 				return fmt.Errorf("unable to start lnc "+


### PR DESCRIPTION
LNC will automatically try to reconnect to the LND node whenever there is an error.

Until now, losing the connection with the LND node made the proxy shut down. When using LNC, we can simply log that we received an error and let the library handle the reconnection.

Because we do not want to overheat the server when the backend lnd node is down, we need to make sure that we add a timeout to the client calls.