### PR TITLE
config: make `sample-conf.yaml` less error prone

### DIFF
--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -26,6 +26,17 @@ profile: 9999
 # Settings for the lnd node used to generate payment requests. All of these
 # options are required.
 authenticator:
+  ## Common fields.
+
+  # The chain network the lnd is active on.
+  network: "simnet"
+ 
+  # Set to true to disable any auth.
+  disable: false
+
+
+  ## Direct LND connection fields.
+
   # The host:port which lnd's RPC can be reached at.
   lndhost: "localhost:10009"
 
@@ -35,9 +46,9 @@ authenticator:
   # The path to lnd's macaroon directory.
   macdir: "/path/to/lnd/data/chain/bitcoin/simnet"
 
-  # The chain network the lnd is active on.
-  network: "simnet"
- 
+
+  ## LNC connection fields.
+
   # The LNC connection passphrase.
   passphrase: "your pairing phrase"
 
@@ -47,9 +58,7 @@ authenticator:
   # Set to true to skip verification of the mailbox server's tls cert.
   devserver: false
 
-  # Set to true to disable any auth.
-  disable: false
-
+  
 # The selected database backend. The current default backend is "sqlite". 
 # Aperture also has support for postgres and etcd.
 dbbackend: "sqlite"

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -39,7 +39,7 @@ authenticator:
   network: "simnet"
  
   # The LNC connection passphrase.
-  passphrase: "my-own-passphrase"
+  passphrase: "your pairing phrase"
 
   # The host:port of the mailbox server to be used.
   mailboxaddress: "mailbox.terminal.lightning.today:443"

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -50,6 +50,9 @@ authenticator:
   ## LNC connection fields.
 
   # The LNC connection passphrase.
+  # NOTE: The passphrase generates a secret for authenticating the LNC
+  # connection. Once a passphrase has been utilized for a connection, it 
+  # cannot be reused in a different server/database.
   passphrase: "your pairing phrase"
 
   # The host:port of the mailbox server to be used.


### PR DESCRIPTION
- Change the passphrase placeholder.
- Group fields by category.