### PR TITLE
GitHub: update caching to maintained fork, continue on error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: docker image cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
+        continue-on-error: true
 
       - name: Generate sql models
         run: make sqlc-check


### PR DESCRIPTION
Since the currently failing step of the sqlc check job is only a cache, it shouldn't cause the whole job to fail.
So we continue on error but also switch to a maintained fork of the cache action which should fix the error in the first place.