### PR TITLE
config: fix profile port arg parsing

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -201,8 +201,8 @@ func (a *Aperture) Start(errChan chan error) error {
 	}
 
 	// Enable http profiling and validate profile port number if requested.
-	if a.cfg.ProfilePort != 0 {
-		if a.cfg.ProfilePort < 1024 || a.cfg.ProfilePort > 65535 {
+	if a.cfg.Profile != 0 {
+		if a.cfg.Profile < 1024 || a.cfg.Profile > 65535 {
 			return fmt.Errorf("the profile port must be between " +
 				"1024 and 65535")
 		}
@@ -212,9 +212,7 @@ func (a *Aperture) Start(errChan chan error) error {
 				"/debug/pprof", http.StatusSeeOther,
 			))
 
-			listenAddr := fmt.Sprintf(
-				"localhost:%d", a.cfg.ProfilePort,
-			)
+			listenAddr := fmt.Sprintf("localhost:%d", a.cfg.Profile)
 
 			log.Infof("Starting profile server at %s", listenAddr)
 			fmt.Println(http.ListenAndServe(listenAddr, nil))

--- a/config.go
+++ b/config.go
@@ -200,8 +200,8 @@ type Config struct {
 	// BaseDir is a custom directory to store all aperture flies.
 	BaseDir string `long:"basedir" description:"Directory to place all of aperture's files in."`
 
-	// ProfilePort is the port on which the pprof profile will be served.
-	ProfilePort uint16 `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65535"`
+	// Profile is the port on which the pprof profile will be served.
+	Profile uint16 `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65535"`
 }
 
 func (c *Config) validate() error {


### PR DESCRIPTION
In this commit, we fix a subtle bug in the parsing of the yaml config. With the way the library works, the attribute name needs to match the config attribute name. Otherwise, parsing just doesn't work.