### PR TITLE
multi: change LSAT name to L402

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ non-custodial on/off ramp for the Lightning Network.
 
 Aperture is a HTTP 402 reverse proxy that supports proxying requests for gRPC
 (HTTP/2) and REST (HTTP/1 and HTTP/2) backends using the [L402 Protocol
-Standard](https://lsat.tech/). L402 is short for: the Lightning HTTP 402
+Standard][l402]. L402 is short for: the Lightning HTTP 402
 protocol.  L402 combines HTTP 402, macaroons, and the Lightning Network to
 create a new standard for authentication and paid services on the web.
 
@@ -22,6 +22,8 @@ system allows one to automate pricing on the fly and allows for a number of
 novel constructs such as automated tier upgrades. In another light, this can be
 viewed as a global HTTP 402 reverse proxy at the load balancing level for web
 services and APIs.
+
+[l402]: https://github.com/lightninglabs/L402
 
 ## Installation / Setup
 

--- a/aperture.go
+++ b/aperture.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	// topLevelKey is the top level key for an etcd cluster where we'll
-	// store all LSAT proxy related data.
+	// store all L402 proxy related data.
 	topLevelKey = "lsat/proxy"
 
 	// etcdKeyDelimeter is the delimeter we'll use for all etcd keys to
@@ -819,7 +819,7 @@ func createProxy(cfg *Config, challenger challenger.Challenger,
 		ServiceLimiter: newStaticServiceLimiter(cfg.Services),
 		Now:            time.Now,
 	})
-	authenticator := auth.NewLsatAuthenticator(minter, challenger)
+	authenticator := auth.NewL402Authenticator(minter, challenger)
 
 	// By default the static file server only returns 404 answers for
 	// security reasons. Serving files from the staticRoot directory has to

--- a/aperture.go
+++ b/aperture.go
@@ -311,7 +311,7 @@ func (a *Aperture) Start(errChan chan error) error {
 		authCfg := a.cfg.Authenticator
 		genInvoiceReq := func(price int64) (*lnrpc.Invoice, error) {
 			return &lnrpc.Invoice{
-				Memo:  "LSAT",
+				Memo:  "L402",
 				Value: price,
 			}, nil
 		}

--- a/aperturedb/secrets.go
+++ b/aperturedb/secrets.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/lightninglabs/aperture/aperturedb/sqlc"
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/mint"
 	"github.com/lightningnetwork/lnd/clock"
 )
@@ -81,11 +81,11 @@ func NewSecretsStore(db BatchedSecretsDB) *SecretsStore {
 // NewSecret creates a new cryptographically random secret which is
 // keyed by the given hash.
 func (s *SecretsStore) NewSecret(ctx context.Context,
-	hash [sha256.Size]byte) ([lsat.SecretSize]byte, error) {
+	hash [sha256.Size]byte) ([l402.SecretSize]byte, error) {
 
-	var secret [lsat.SecretSize]byte
+	var secret [l402.SecretSize]byte
 	if _, err := rand.Read(secret[:]); err != nil {
-		return [lsat.SecretSize]byte{}, err
+		return [l402.SecretSize]byte{}, err
 	}
 
 	var writeTxOpts SecretsDBTxOptions
@@ -103,7 +103,7 @@ func (s *SecretsStore) NewSecret(ctx context.Context,
 	})
 
 	if err != nil {
-		return [lsat.SecretSize]byte{}, fmt.Errorf("unable to insert "+
+		return [l402.SecretSize]byte{}, fmt.Errorf("unable to insert "+
 			"new secret for hash(%x): %w", hash, err)
 	}
 
@@ -114,9 +114,9 @@ func (s *SecretsStore) NewSecret(ctx context.Context,
 // corresponds to the given hash. If there is no secret, then
 // ErrSecretNotFound is returned.
 func (s *SecretsStore) GetSecret(ctx context.Context,
-	hash [sha256.Size]byte) ([lsat.SecretSize]byte, error) {
+	hash [sha256.Size]byte) ([l402.SecretSize]byte, error) {
 
-	var secret [lsat.SecretSize]byte
+	var secret [l402.SecretSize]byte
 	readOpts := NewSecretsDBReadTx()
 	err := s.db.ExecTx(ctx, &readOpts, func(db SecretsDB) error {
 		secretRow, err := db.GetSecretByHash(ctx, hash[:])
@@ -134,7 +134,7 @@ func (s *SecretsStore) GetSecret(ctx context.Context,
 	})
 
 	if err != nil {
-		return [lsat.SecretSize]byte{}, fmt.Errorf("unable to get "+
+		return [l402.SecretSize]byte{}, fmt.Errorf("unable to get "+
 			"secret for hash(%x): %w", hash, err)
 	}
 

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -103,9 +103,12 @@ func (l *L402Authenticator) FreshChallengeHeader(r *http.Request,
 		log.Errorf("Error serializing L402: %v", err)
 	}
 
+	header := http.Header{
+		"Content-Type": []string{"application/grpc"},
+	}
+
 	str := fmt.Sprintf("macaroon=\"%s\", invoice=\"%s\"",
 		base64.StdEncoding.EncodeToString(macBytes), paymentRequest)
-	header := r.Header
 
 	// Old loop software (via ClientInterceptor code of aperture) looks
 	// for "LSAT" in the first instance of WWW-Authenticate header, so

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -71,6 +71,14 @@ func (l *L402Authenticator) Accept(header *http.Header, serviceName string) bool
 	return true
 }
 
+const (
+	// lsatAuthScheme is an outdated RFC 7235 auth-scheme used by aperture.
+	lsatAuthScheme = "LSAT"
+
+	// l402AuthScheme is the current RFC 7235 auth-scheme used by aperture.
+	l402AuthScheme = "L402"
+)
+
 // FreshChallengeHeader returns a header containing a challenge for the user to
 // complete.
 //
@@ -95,11 +103,19 @@ func (l *L402Authenticator) FreshChallengeHeader(r *http.Request,
 		log.Errorf("Error serializing L402: %v", err)
 	}
 
-	str := fmt.Sprintf("LSAT macaroon=\"%s\", invoice=\"%s\"",
+	str := fmt.Sprintf("macaroon=\"%s\", invoice=\"%s\"",
 		base64.StdEncoding.EncodeToString(macBytes), paymentRequest)
 	header := r.Header
-	header.Set("WWW-Authenticate", str)
 
-	log.Debugf("Created new challenge header: [%s]", str)
+	// Old loop software (via ClientInterceptor code of aperture) looks
+	// for "LSAT" in the first instance of WWW-Authenticate header, so
+	// legacy header must go first not to break backward compatibility.
+	lsatValue := lsatAuthScheme + " " + str
+	l402Value := l402AuthScheme + " " + str
+	header.Set("WWW-Authenticate", lsatValue)
+	log.Debugf("Created new challenge header: [%s]", lsatValue)
+	header.Add("WWW-Authenticate", l402Value)
+	log.Debugf("Created new challenge header: [%s]", l402Value)
+
 	return header, nil
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/aperture/auth"
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"gopkg.in/macaroon.v2"
 )
 
@@ -21,8 +21,8 @@ func createDummyMacHex(preimage string) string {
 	if err != nil {
 		panic(err)
 	}
-	preimageCaveat := lsat.Caveat{Condition: lsat.PreimageKey, Value: preimage}
-	err = lsat.AddFirstPartyCaveats(dummyMac, preimageCaveat)
+	preimageCaveat := l402.Caveat{Condition: l402.PreimageKey, Value: preimage}
+	err = l402.AddFirstPartyCaveats(dummyMac, preimageCaveat)
 	if err != nil {
 		panic(err)
 	}
@@ -33,9 +33,9 @@ func createDummyMacHex(preimage string) string {
 	return hex.EncodeToString(macBytes)
 }
 
-// TestLsatAuthenticator tests that the authenticator properly handles auth
+// TestL402Authenticator tests that the authenticator properly handles auth
 // headers and the tokens contained in them.
-func TestLsatAuthenticator(t *testing.T) {
+func TestL402Authenticator(t *testing.T) {
 	var (
 		testPreimage = "49349dfea4abed3cd14f6d356afa83de" +
 			"9787b609f088c8df09bacc7b4bd21b39"
@@ -65,21 +65,21 @@ func TestLsatAuthenticator(t *testing.T) {
 			{
 				id: "empty auth header",
 				header: &http.Header{
-					lsat.HeaderAuthorization: []string{},
+					l402.HeaderAuthorization: []string{},
 				},
 				result: false,
 			},
 			{
 				id: "zero length auth header",
 				header: &http.Header{
-					lsat.HeaderAuthorization: []string{""},
+					l402.HeaderAuthorization: []string{""},
 				},
 				result: false,
 			},
 			{
 				id: "invalid auth header",
 				header: &http.Header{
-					lsat.HeaderAuthorization: []string{
+					l402.HeaderAuthorization: []string{
 						"foo",
 					},
 				},
@@ -88,21 +88,21 @@ func TestLsatAuthenticator(t *testing.T) {
 			{
 				id: "invalid macaroon metadata header",
 				header: &http.Header{
-					lsat.HeaderMacaroonMD: []string{"foo"},
+					l402.HeaderMacaroonMD: []string{"foo"},
 				},
 				result: false,
 			},
 			{
 				id: "invalid macaroon header",
 				header: &http.Header{
-					lsat.HeaderMacaroon: []string{"foo"},
+					l402.HeaderMacaroon: []string{"foo"},
 				},
 				result: false,
 			},
 			{
 				id: "valid auth header",
 				header: &http.Header{
-					lsat.HeaderAuthorization: []string{
+					l402.HeaderAuthorization: []string{
 						"LSAT " + testMacBase64 + ":" +
 							testPreimage,
 					},
@@ -112,7 +112,7 @@ func TestLsatAuthenticator(t *testing.T) {
 			{
 				id: "valid macaroon metadata header",
 				header: &http.Header{
-					lsat.HeaderMacaroonMD: []string{
+					l402.HeaderMacaroonMD: []string{
 						testMacHex,
 					}},
 				result: true,
@@ -120,7 +120,7 @@ func TestLsatAuthenticator(t *testing.T) {
 			{
 				id: "valid macaroon header",
 				header: &http.Header{
-					lsat.HeaderMacaroon: []string{
+					l402.HeaderMacaroon: []string{
 						testMacHex,
 					},
 				},
@@ -129,7 +129,7 @@ func TestLsatAuthenticator(t *testing.T) {
 			{
 				id: "valid macaroon header, wrong invoice state",
 				header: &http.Header{
-					lsat.HeaderMacaroon: []string{
+					l402.HeaderMacaroon: []string{
 						testMacHex,
 					},
 				},
@@ -140,7 +140,7 @@ func TestLsatAuthenticator(t *testing.T) {
 	)
 
 	c := &mockChecker{}
-	a := auth.NewLsatAuthenticator(&mockMint{}, c)
+	a := auth.NewL402Authenticator(&mockMint{}, c)
 	for _, testCase := range headerTests {
 		c.err = testCase.checkErr
 		result := a.Accept(testCase.header, "test")

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -100,10 +100,32 @@ func TestL402Authenticator(t *testing.T) {
 				result: false,
 			},
 			{
-				id: "valid auth header",
+				id: "valid auth header (both LSAT and L402)",
 				header: &http.Header{
 					l402.HeaderAuthorization: []string{
 						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: true,
+			},
+			{
+				id: "valid auth header (LSAT only)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: true,
+			},
+			{
+				id: "valid auth header (L402 only)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
 							testPreimage,
 					},
 				},

--- a/auth/interface.go
+++ b/auth/interface.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/mint"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -30,14 +30,14 @@ type Authenticator interface {
 	FreshChallengeHeader(*http.Request, string, int64) (http.Header, error)
 }
 
-// Minter is an entity that is able to mint and verify LSATs for a set of
+// Minter is an entity that is able to mint and verify L402s for a set of
 // services.
 type Minter interface {
-	// MintLSAT mints a new LSAT for the target services.
-	MintLSAT(context.Context, ...lsat.Service) (*macaroon.Macaroon, string, error)
+	// MintL402 mints a new L402 for the target services.
+	MintL402(context.Context, ...l402.Service) (*macaroon.Macaroon, string, error)
 
-	// VerifyLSAT attempts to verify an LSAT with the given parameters.
-	VerifyLSAT(context.Context, *mint.VerificationParams) error
+	// VerifyL402 attempts to verify an L402 with the given parameters.
+	VerifyL402(context.Context, *mint.VerificationParams) error
 }
 
 // InvoiceChecker is an entity that is able to check the status of an invoice,

--- a/auth/mock_authenticator.go
+++ b/auth/mock_authenticator.go
@@ -34,7 +34,10 @@ func (a MockAuthenticator) Accept(header *http.Header, _ string) bool {
 func (a MockAuthenticator) FreshChallengeHeader(r *http.Request,
 	_ string, _ int64) (http.Header, error) {
 
-	header := r.Header
+	header := http.Header{
+		"Content-Type": []string{"application/grpc"},
+	}
+
 	str := "macaroon=\"AGIAJEemVQUTEyNCR0exk7ek9" +
 		"0Cg==\", invoice=\"lnbc1500n1pw5kjhmpp5fu6xhthlt2vucm" +
 		"zkx6c7wtlh2r625r30cyjsfqhu8rsx4xpz5lwqdpa2fjkzep6yptk" +
@@ -44,5 +47,6 @@ func (a MockAuthenticator) FreshChallengeHeader(r *http.Request,
 		"y3ngqjcym5a\""
 	header.Set("WWW-Authenticate", lsatAuthScheme+" "+str)
 	header.Add("WWW-Authenticate", l402AuthScheme+" "+str)
+
 	return header, nil
 }

--- a/auth/mock_authenticator.go
+++ b/auth/mock_authenticator.go
@@ -35,13 +35,14 @@ func (a MockAuthenticator) FreshChallengeHeader(r *http.Request,
 	_ string, _ int64) (http.Header, error) {
 
 	header := r.Header
-	header.Set(
-		"WWW-Authenticate", "LSAT macaroon=\"AGIAJEemVQUTEyNCR0exk7ek9"+
-			"0Cg==\", invoice=\"lnbc1500n1pw5kjhmpp5fu6xhthlt2vucm"+
-			"zkx6c7wtlh2r625r30cyjsfqhu8rsx4xpz5lwqdpa2fjkzep6yptk"+
-			"sct5yp5hxgrrv96hx6twvusycn3qv9jx7ur5d9hkugr5dusx6cqzp"+
-			"gxqr23s79ruapxc4j5uskt4htly2salw4drq979d7rcela9wz02el"+
-			"hypmdzmzlnxuknpgfyfm86pntt8vvkvffma5qc9n50h4mvqhngadq"+
-			"y3ngqjcym5a\"")
+	str := "macaroon=\"AGIAJEemVQUTEyNCR0exk7ek9" +
+		"0Cg==\", invoice=\"lnbc1500n1pw5kjhmpp5fu6xhthlt2vucm" +
+		"zkx6c7wtlh2r625r30cyjsfqhu8rsx4xpz5lwqdpa2fjkzep6yptk" +
+		"sct5yp5hxgrrv96hx6twvusycn3qv9jx7ur5d9hkugr5dusx6cqzp" +
+		"gxqr23s79ruapxc4j5uskt4htly2salw4drq979d7rcela9wz02el" +
+		"hypmdzmzlnxuknpgfyfm86pntt8vvkvffma5qc9n50h4mvqhngadq" +
+		"y3ngqjcym5a\""
+	header.Set("WWW-Authenticate", lsatAuthScheme+" "+str)
+	header.Add("WWW-Authenticate", l402AuthScheme+" "+str)
 	return header, nil
 }

--- a/auth/mock_test.go
+++ b/auth/mock_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/aperture/auth"
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/mint"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -17,13 +17,13 @@ type mockMint struct {
 
 var _ auth.Minter = (*mockMint)(nil)
 
-func (m *mockMint) MintLSAT(_ context.Context,
-	services ...lsat.Service) (*macaroon.Macaroon, string, error) {
+func (m *mockMint) MintL402(_ context.Context,
+	services ...l402.Service) (*macaroon.Macaroon, string, error) {
 
 	return nil, "", nil
 }
 
-func (m *mockMint) VerifyLSAT(_ context.Context, p *mint.VerificationParams) error {
+func (m *mockMint) VerifyL402(_ context.Context, p *mint.VerificationParams) error {
 	return nil
 }
 

--- a/challenger/lnc.go
+++ b/challenger/lnc.go
@@ -10,7 +10,7 @@ import (
 )
 
 // LNCChallenger is a challenger that uses LNC to connect to an lnd backend to
-// create new LSAT payment challenges.
+// create new L402 payment challenges.
 type LNCChallenger struct {
 	lndChallenger *LndChallenger
 	nodeConn      *lnc.NodeConn
@@ -61,7 +61,7 @@ func (l *LNCChallenger) Stop() {
 	l.lndChallenger.Stop()
 }
 
-// NewChallenge creates a new LSAT payment challenge, returning a payment
+// NewChallenge creates a new L402 payment challenge, returning a payment
 // request (invoice) and the corresponding payment hash.
 //
 // NOTE: This is part of the mint.Challenger interface.

--- a/challenger/lnd.go
+++ b/challenger/lnd.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
-// LndChallenger is a challenger that uses an lnd backend to create new LSAT
+// LndChallenger is a challenger that uses an lnd backend to create new L402
 // payment challenges.
 type LndChallenger struct {
 	client        InvoiceClient
@@ -247,7 +247,7 @@ func (l *LndChallenger) Stop() {
 	l.wg.Wait()
 }
 
-// NewChallenge creates a new LSAT payment challenge, returning a payment
+// NewChallenge creates a new L402 payment challenge, returning a payment
 // request (invoice) and the corresponding payment hash.
 //
 // NOTE: This is part of the mint.Challenger interface.

--- a/l402/caveat.go
+++ b/l402/caveat.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"errors"
@@ -20,10 +20,10 @@ var (
 		"\"condition=value\"")
 )
 
-// Caveat is a predicate that can be applied to an LSAT in order to restrict its
-// use in some form. Caveats are evaluated during LSAT verification after the
-// LSAT's signature is verified. The predicate of each caveat must hold true in
-// order to successfully validate an LSAT.
+// Caveat is a predicate that can be applied to an L402 in order to restrict its
+// use in some form. Caveats are evaluated during L402 verification after the
+// L402's signature is verified. The predicate of each caveat must hold true in
+// order to successfully validate an L402.
 type Caveat struct {
 	// Condition serves as a way to identify a caveat and how to satisfy it.
 	Condition string
@@ -92,11 +92,11 @@ func HasCaveat(m *macaroon.Macaroon, cond string) (string, bool) {
 	return *value, true
 }
 
-// VerifyCaveats determines whether every relevant caveat of an LSAT holds true.
+// VerifyCaveats determines whether every relevant caveat of an L402 holds true.
 // A caveat is considered relevant if a satisfier is provided for it, which is
 // what we'll use as their evaluation.
 //
-// NOTE: The caveats provided should be in the same order as in the LSAT to
+// NOTE: The caveats provided should be in the same order as in the L402 to
 // ensure the correctness of each satisfier's SatisfyPrevious.
 func VerifyCaveats(caveats []Caveat, satisfiers ...Satisfier) error {
 	// Construct a set of our satisfiers to determine which caveats we know

--- a/l402/caveat_test.go
+++ b/l402/caveat_test.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"errors"
@@ -79,7 +79,7 @@ func TestHasCaveat(t *testing.T) {
 		t.Fatal("found unexpected caveat with unknown condition")
 	}
 
-	// Add two caveats, one in a valid LSAT format and another invalid.
+	// Add two caveats, one in a valid L402 format and another invalid.
 	// We'll test that we're still able to determine the macaroon contains
 	// the valid caveat even though there is one that is invalid.
 	invalidCaveat := []byte("invalid")

--- a/l402/client_interceptor.go
+++ b/l402/client_interceptor.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"context"
@@ -44,12 +44,12 @@ const (
 	AuthHeader = "WWW-Authenticate"
 
 	// DefaultMaxCostSats is the default maximum amount in satoshis that we
-	// are going to pay for an LSAT automatically. Does not include routing
+	// are going to pay for an L402 automatically. Does not include routing
 	// fees.
 	DefaultMaxCostSats = 1000
 
 	// DefaultMaxRoutingFeeSats is the default maximum routing fee in
-	// satoshis that we are going to pay to acquire an LSAT token.
+	// satoshis that we are going to pay to acquire an L402 token.
 	DefaultMaxRoutingFeeSats = 10
 
 	// PaymentTimeout is the maximum time we allow a payment to take before
@@ -76,7 +76,7 @@ var (
 		"failure state")
 )
 
-// ClientInterceptor is a gRPC client interceptor that can handle LSAT
+// ClientInterceptor is a gRPC client interceptor that can handle L402
 // authentication challenges with embedded payment requests. It uses a
 // connection to lnd to automatically pay for an authentication token.
 type ClientInterceptor struct {
@@ -90,7 +90,7 @@ type ClientInterceptor struct {
 }
 
 // NewInterceptor creates a new gRPC client interceptor that uses the provided
-// lnd connection to automatically acquire and pay for LSAT tokens, unless the
+// lnd connection to automatically acquire and pay for L402 tokens, unless the
 // indicated store already contains a usable token.
 func NewInterceptor(lnd *lndclient.LndServices, store Store,
 	rpcCallTimeout time.Duration, maxCost,
@@ -140,7 +140,7 @@ func (i *ClientInterceptor) UnaryInterceptor(ctx context.Context, method string,
 	}
 
 	// Try executing the call now. If anything goes wrong, we only handle
-	// the LSAT error message that comes in the form of a gRPC status error.
+	// the L402 error message that comes in the form of a gRPC status error.
 	rpcCtx, cancel := context.WithTimeout(ctx, i.callTimeout)
 	defer cancel()
 	err = invoker(rpcCtx, method, req, reply, cc, iCtx.opts...)
@@ -155,7 +155,7 @@ func (i *ClientInterceptor) UnaryInterceptor(ctx context.Context, method string,
 		return err
 	}
 
-	// Execute the same request again, now with the LSAT
+	// Execute the same request again, now with the L402
 	// token added as an RPC credential.
 	rpcCtx2, cancel2 := context.WithTimeout(ctx, i.callTimeout)
 	defer cancel2()
@@ -188,7 +188,7 @@ func (i *ClientInterceptor) StreamInterceptor(ctx context.Context,
 	}
 
 	// Try establishing the stream now. If anything goes wrong, we only
-	// handle the LSAT error message that comes in the form of a gRPC status
+	// handle the L402 error message that comes in the form of a gRPC status
 	// error. The context of a stream will be used for the whole lifetime of
 	// it, so we can't really clamp down on the initial call with a timeout.
 	stream, err := streamer(ctx, desc, cc, method, iCtx.opts...)
@@ -203,7 +203,7 @@ func (i *ClientInterceptor) StreamInterceptor(ctx context.Context,
 		return nil, err
 	}
 
-	// Execute the same request again, now with the LSAT token added
+	// Execute the same request again, now with the L402 token added
 	// as an RPC credential.
 	return streamer(ctx, desc, cc, method, iCtx.opts...)
 }
@@ -240,7 +240,7 @@ func (i *ClientInterceptor) newInterceptContext(ctx context.Context,
 	// this call. We also never send a pending payment to the server since
 	// we know it's not valid.
 	case !iCtx.token.isPending():
-		if err = i.addLsatCredentials(iCtx); err != nil {
+		if err = i.addL402Credentials(iCtx); err != nil {
 			log.Errorf("Adding macaroon to request failed: %v", err)
 			return nil, fmt.Errorf("adding macaroon failed: %v",
 				err)
@@ -250,8 +250,8 @@ func (i *ClientInterceptor) newInterceptContext(ctx context.Context,
 	// We need a way to extract the response headers sent by the server.
 	// This can only be done through the experimental grpc.Trailer call
 	// option. We execute the request and inspect the error. If it's the
-	// LSAT specific payment required error, we might execute the same
-	// method again later with the paid LSAT token.
+	// L402 specific payment required error, we might execute the same
+	// method again later with the paid L402 token.
 	iCtx.opts = append(iCtx.opts, grpc.Trailer(iCtx.metadata))
 	return iCtx, nil
 }
@@ -262,8 +262,8 @@ func (i *ClientInterceptor) handlePayment(iCtx *interceptContext) error {
 	switch {
 	// Resume/track a pending payment if it was interrupted for some reason.
 	case iCtx.token != nil && iCtx.token.isPending():
-		log.Infof("Payment of LSAT token is required, resuming/" +
-			"tracking previous payment from pending LSAT token")
+		log.Infof("Payment of L402 token is required, resuming/" +
+			"tracking previous payment from pending L402 token")
 		err := i.trackPayment(iCtx.mainCtx, iCtx.token)
 
 		// If the payment failed for good, it will never come back to a
@@ -277,9 +277,9 @@ func (i *ClientInterceptor) handlePayment(iCtx *interceptContext) error {
 			}
 
 			// Let's try again by paying for the new token.
-			log.Infof("Retrying payment of LSAT token invoice")
+			log.Infof("Retrying payment of L402 token invoice")
 			var err error
-			iCtx.token, err = i.payLsatToken(
+			iCtx.token, err = i.payL402Token(
 				iCtx.mainCtx, iCtx.metadata,
 			)
 			if err != nil {
@@ -295,27 +295,27 @@ func (i *ClientInterceptor) handlePayment(iCtx *interceptContext) error {
 	// We don't have a token yet, try to get a new one.
 	case iCtx.token == nil:
 		// We don't have a token yet, get a new one.
-		log.Infof("Payment of LSAT token is required, paying invoice")
+		log.Infof("Payment of L402 token is required, paying invoice")
 		var err error
-		iCtx.token, err = i.payLsatToken(iCtx.mainCtx, iCtx.metadata)
+		iCtx.token, err = i.payL402Token(iCtx.mainCtx, iCtx.metadata)
 		if err != nil {
 			return err
 		}
 
 	// We have a token and it's valid, nothing more to do here.
 	default:
-		log.Debugf("Found valid LSAT token to add to request")
+		log.Debugf("Found valid L402 token to add to request")
 	}
 
-	if err := i.addLsatCredentials(iCtx); err != nil {
+	if err := i.addL402Credentials(iCtx); err != nil {
 		log.Errorf("Adding macaroon to request failed: %v", err)
 		return fmt.Errorf("adding macaroon failed: %v", err)
 	}
 	return nil
 }
 
-// addLsatCredentials adds an LSAT token to the given intercept context.
-func (i *ClientInterceptor) addLsatCredentials(iCtx *interceptContext) error {
+// addL402Credentials adds an L402 token to the given intercept context.
+func (i *ClientInterceptor) addL402Credentials(iCtx *interceptContext) error {
 	if iCtx.token == nil {
 		return fmt.Errorf("cannot add nil token to context")
 	}
@@ -330,10 +330,10 @@ func (i *ClientInterceptor) addLsatCredentials(iCtx *interceptContext) error {
 	return nil
 }
 
-// payLsatToken reads the payment challenge from the response metadata and tries
-// to pay the invoice encoded in them, returning a paid LSAT token if
+// payL402Token reads the payment challenge from the response metadata and tries
+// to pay the invoice encoded in them, returning a paid L402 token if
 // successful.
-func (i *ClientInterceptor) payLsatToken(ctx context.Context, md *metadata.MD) (
+func (i *ClientInterceptor) payL402Token(ctx context.Context, md *metadata.MD) (
 	*Token, error) {
 
 	// First parse the authentication header that was stored in the
@@ -364,7 +364,7 @@ func (i *ClientInterceptor) payLsatToken(ctx context.Context, md *metadata.MD) (
 	// Check that the charged amount does not exceed our maximum cost.
 	maxCostMsat := lnwire.NewMSatFromSatoshis(i.maxCost)
 	if invoice.MilliSat != nil && *invoice.MilliSat > maxCostMsat {
-		return nil, fmt.Errorf("cannot pay for LSAT automatically, "+
+		return nil, fmt.Errorf("cannot pay for L402 automatically, "+
 			"cost of %d msat exceeds configured max cost of %d "+
 			"msat", *invoice.MilliSat, maxCostMsat)
 	}

--- a/l402/client_interceptor_test.go
+++ b/l402/client_interceptor_test.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"context"
@@ -219,7 +219,7 @@ var (
 		},
 		expectLndCall: false,
 		expectToken:   false,
-		expectInterceptErr: "cannot pay for LSAT automatically, cost " +
+		expectInterceptErr: "cannot pay for L402 automatically, cost " +
 			"of 500000 msat exceeds configured max cost of " +
 			"100000 msat",
 		expectBackendCalls:  1,
@@ -262,7 +262,7 @@ func invoker(opts []grpc.CallOption) error {
 	return backendErr
 }
 
-// TestUnaryInterceptor tests that the interceptor can handle LSAT protocol
+// TestUnaryInterceptor tests that the interceptor can handle L402 protocol
 // responses for unary calls and pay the token.
 func TestUnaryInterceptor(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
@@ -290,7 +290,7 @@ func TestUnaryInterceptor(t *testing.T) {
 	}
 }
 
-// TestStreamInterceptor tests that the interceptor can handle LSAT protocol
+// TestStreamInterceptor tests that the interceptor can handle L402 protocol
 // responses in streams and pay the token.
 func TestStreamInterceptor(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)

--- a/l402/client_interceptor_test.go
+++ b/l402/client_interceptor_test.go
@@ -23,7 +23,7 @@ type interceptTestCase struct {
 	name                string
 	initialPreimage     *lntypes.Preimage
 	interceptor         *ClientInterceptor
-	resetCb             func()
+	resetCb             func(addL402 bool)
 	expectLndCall       bool
 	expectSecondLndCall bool
 	sendPaymentCb       func(*testing.T, test.PaymentChannelMessage)
@@ -73,17 +73,19 @@ var (
 	testMacHex      = hex.EncodeToString(testMacBytes)
 	paidPreimage    = lntypes.Preimage{1, 2, 3, 4, 5}
 	backendErr      error
-	backendAuth     = ""
+	backendAuth     = []string{}
 	callMD          map[string]string
 	numBackendCalls = 0
 	overallWg       sync.WaitGroup
 	backendWg       sync.WaitGroup
 
 	testCases = []interceptTestCase{{
-		name:                "no auth required happy path",
-		initialPreimage:     nil,
-		interceptor:         interceptor,
-		resetCb:             func() { resetBackend(nil, "") },
+		name:            "no auth required happy path",
+		initialPreimage: nil,
+		interceptor:     interceptor,
+		resetCb: func(addL402 bool) {
+			resetBackend(nil, []string{})
+		},
 		expectLndCall:       false,
 		expectToken:         false,
 		expectBackendCalls:  1,
@@ -93,10 +95,10 @@ var (
 		name:            "auth required, no token yet",
 		initialPreimage: nil,
 		interceptor:     interceptor,
-		resetCb: func() {
+		resetCb: func(addL402 bool) {
 			resetBackend(
 				status.New(GRPCErrCode, GRPCErrMessage).Err(),
-				makeAuthHeader(testMacBytes),
+				makeAuthHeaders(testMacBytes, addL402),
 			)
 		},
 		expectLndCall: true,
@@ -107,7 +109,7 @@ var (
 
 			// The next call to the "backend" shouldn't return an
 			// error.
-			resetBackend(nil, "")
+			resetBackend(nil, []string{})
 			msg.Done <- lndclient.PaymentResult{
 				Preimage: paidPreimage,
 				PaidAmt:  123,
@@ -124,10 +126,12 @@ var (
 		expectMacaroonCall1: false,
 		expectMacaroonCall2: true,
 	}, {
-		name:                "auth required, has token",
-		initialPreimage:     &paidPreimage,
-		interceptor:         interceptor,
-		resetCb:             func() { resetBackend(nil, "") },
+		name:            "auth required, has token",
+		initialPreimage: &paidPreimage,
+		interceptor:     interceptor,
+		resetCb: func(addL402 bool) {
+			resetBackend(nil, []string{})
+		},
 		expectLndCall:       false,
 		expectToken:         true,
 		expectBackendCalls:  1,
@@ -137,10 +141,10 @@ var (
 		name:            "auth required, has pending token",
 		initialPreimage: &zeroPreimage,
 		interceptor:     interceptor,
-		resetCb: func() {
+		resetCb: func(addL402 bool) {
 			resetBackend(
 				status.New(GRPCErrCode, GRPCErrMessage).Err(),
-				makeAuthHeader(testMacBytes),
+				makeAuthHeaders(testMacBytes, addL402),
 			)
 		},
 		expectLndCall: true,
@@ -154,7 +158,7 @@ var (
 
 			// The next call to the "backend" shouldn't return an
 			// error.
-			resetBackend(nil, "")
+			resetBackend(nil, []string{})
 			msg.Updates <- lndclient.PaymentStatus{
 				State:    lnrpc.Payment_SUCCEEDED,
 				Preimage: paidPreimage,
@@ -168,10 +172,10 @@ var (
 		name:            "auth required, has pending but expired token",
 		initialPreimage: &zeroPreimage,
 		interceptor:     interceptor,
-		resetCb: func() {
+		resetCb: func(addL402 bool) {
 			resetBackend(
 				status.New(GRPCErrCode, GRPCErrMessage).Err(),
-				makeAuthHeader(testMacBytes),
+				makeAuthHeaders(testMacBytes, addL402),
 			)
 		},
 		expectLndCall:       true,
@@ -183,7 +187,7 @@ var (
 
 			// The next call to the "backend" shouldn't return an
 			// error.
-			resetBackend(nil, "")
+			resetBackend(nil, []string{})
 			msg.Done <- lndclient.PaymentResult{
 				Preimage: paidPreimage,
 				PaidAmt:  123,
@@ -195,7 +199,7 @@ var (
 
 			// The next call to the "backend" shouldn't return an
 			// error.
-			resetBackend(nil, "")
+			resetBackend(nil, []string{})
 			msg.Updates <- lndclient.PaymentStatus{
 				State: lnrpc.Payment_FAILED,
 			}
@@ -211,10 +215,10 @@ var (
 			&lnd.LndServices, store, testTimeout, 100,
 			DefaultMaxRoutingFeeSats, false,
 		),
-		resetCb: func() {
+		resetCb: func(addL402 bool) {
 			resetBackend(
 				status.New(GRPCErrCode, GRPCErrMessage).Err(),
-				makeAuthHeader(testMacBytes),
+				makeAuthHeaders(testMacBytes, addL402),
 			)
 		},
 		expectLndCall: false,
@@ -230,7 +234,7 @@ var (
 
 // resetBackend is used by the test cases to define the behaviour of the
 // simulated backend and reset its starting conditions.
-func resetBackend(expectedErr error, expectedAuth string) {
+func resetBackend(expectedErr error, expectedAuth []string) {
 	backendErr = expectedErr
 	backendAuth = expectedAuth
 	callMD = nil
@@ -252,9 +256,9 @@ func invoker(opts []grpc.CallOption) error {
 
 		// Should we simulate an auth header response?
 		trailer, ok := opt.(grpc.TrailerCallOption)
-		if ok && backendAuth != "" {
+		if ok && len(backendAuth) != 0 {
 			trailer.TrailerAddr.Set(
-				AuthHeader, backendAuth,
+				AuthHeader, backendAuth...,
 			)
 		}
 	}
@@ -284,8 +288,11 @@ func TestUnaryInterceptor(t *testing.T) {
 				ctx, "", nil, nil, nil, unaryInvoker, nil,
 			)
 		}
-		t.Run(tc.name, func(t *testing.T) {
-			testInterceptor(t, tc, intercept)
+		t.Run(tc.name+" with LSAT header only", func(t *testing.T) {
+			testInterceptor(t, tc, false, intercept)
+		})
+		t.Run(tc.name+" with LSAT+L402 headers", func(t *testing.T) {
+			testInterceptor(t, tc, true, intercept)
 		})
 	}
 }
@@ -314,18 +321,21 @@ func TestStreamInterceptor(t *testing.T) {
 			)
 			return err
 		}
-		t.Run(tc.name, func(t *testing.T) {
-			testInterceptor(t, tc, intercept)
+		t.Run(tc.name+" with LSAT header only", func(t *testing.T) {
+			testInterceptor(t, tc, false, intercept)
+		})
+		t.Run(tc.name+" with LSAT+L402 headers", func(t *testing.T) {
+			testInterceptor(t, tc, true, intercept)
 		})
 	}
 }
 
-func testInterceptor(t *testing.T, tc interceptTestCase,
+func testInterceptor(t *testing.T, tc interceptTestCase, addL402 bool,
 	intercept func() error) {
 
 	// Initial condition and simulated backend call.
 	store.token = makeToken(tc.initialPreimage)
-	tc.resetCb()
+	tc.resetCb(addL402)
 	numBackendCalls = 0
 	backendWg.Add(1)
 	overallWg.Add(1)
@@ -434,13 +444,19 @@ func serializeMac(mac *macaroon.Macaroon) []byte {
 	return macBytes
 }
 
-func makeAuthHeader(macBytes []byte) string {
+func makeAuthHeaders(macBytes []byte, addL402 bool) []string {
 	// Testnet invoice over 500 sats.
 	invoice := "lntb5u1p0pskpmpp5jzw9xvdast2g5lm5tswq6n64t2epe3f4xav43dyd" +
 		"239qr8h3yllqdqqcqzpgsp5m8sfjqgugthk66q3tr4gsqr5rh740jrq9x4l0" +
 		"kvj5e77nmwqvpnq9qy9qsq72afzu7sfuppzqg3q2pn49hlh66rv7w60h2rua" +
 		"hx857g94s066yzxcjn4yccqc79779sd232v9ewluvu0tmusvht6r99rld8xs" +
 		"k287cpyac79r"
-	return fmt.Sprintf("LSAT macaroon=\"%s\", invoice=\"%s\"",
+	str := fmt.Sprintf("macaroon=\"%s\", invoice=\"%s\"",
 		base64.StdEncoding.EncodeToString(macBytes), invoice)
+	values := []string{"LSAT " + str}
+	if addL402 {
+		values = append(values, "L402 "+str)
+	}
+
+	return values
 }

--- a/l402/context.go
+++ b/l402/context.go
@@ -1,10 +1,10 @@
-package lsat
+package l402
 
 import (
 	"context"
 )
 
-// ContextKey is the type that we use to identify LSAT specific values in the
+// ContextKey is the type that we use to identify L402 specific values in the
 // request context. We wrap the string inside a struct because of this comment
 // in the context API: "The provided key must be comparable and should not be of
 // type string or any other built-in type to avoid collisions between packages

--- a/l402/credential.go
+++ b/l402/credential.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"context"

--- a/l402/header.go
+++ b/l402/header.go
@@ -56,9 +56,6 @@ func FromHeader(header *http.Header) (*macaroon.Macaroon, lntypes.Preimage, erro
 		for _, authHeader := range authHeaders {
 			log.Debugf("Trying to authorize with header value "+
 				"[%s].", authHeader)
-			if !authRegex.MatchString(authHeader) {
-				continue
-			}
 			matches = authRegex.FindStringSubmatch(authHeader)
 			if len(matches) != 4 {
 				continue

--- a/l402/header.go
+++ b/l402/header.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"encoding/base64"
@@ -14,15 +14,15 @@ import (
 
 const (
 	// HeaderAuthorization is the HTTP header field name that is used to
-	// send the LSAT by REST clients.
+	// send the L402 by REST clients.
 	HeaderAuthorization = "Authorization"
 
 	// HeaderMacaroonMD is the HTTP header field name that is used to send
-	// the LSAT by certain REST and gRPC clients.
+	// the L402 by certain REST and gRPC clients.
 	HeaderMacaroonMD = "Grpc-Metadata-Macaroon"
 
 	// HeaderMacaroon is the HTTP header field name that is used to send the
-	// LSAT by our own gRPC clients.
+	// L402 by our own gRPC clients.
 	HeaderMacaroon = "Macaroon"
 )
 
@@ -34,7 +34,7 @@ var (
 // FromHeader tries to extract authentication information from HTTP headers.
 // There are two supported formats that can be sent in three different header
 // fields:
-//  1. Authorization: LSAT <macBase64>:<preimageHex>
+//  1. Authorization: L402 <macBase64>:<preimageHex>
 //  2. Grpc-Metadata-Macaroon: <macHex>
 //  3. Macaroon: <macHex>
 //
@@ -126,7 +126,7 @@ func FromHeader(header *http.Header) (*macaroon.Macaroon, lntypes.Preimage, erro
 }
 
 // SetHeader sets the provided authentication elements as the default/standard
-// HTTP header for the LSAT protocol.
+// HTTP header for the L402 protocol.
 func SetHeader(header *http.Header, mac *macaroon.Macaroon,
 	preimage fmt.Stringer) error {
 

--- a/l402/header.go
+++ b/l402/header.go
@@ -27,13 +27,15 @@ const (
 )
 
 var (
-	authRegex  = regexp.MustCompile("LSAT (.*?):([a-f0-9]{64})")
-	authFormat = "LSAT %s:%s"
+	authRegex        = regexp.MustCompile("(LSAT|L402) (.*?):([a-f0-9]{64})")
+	authFormatLegacy = "LSAT %s:%s"
+	authFormat       = "L402 %s:%s"
 )
 
 // FromHeader tries to extract authentication information from HTTP headers.
-// There are two supported formats that can be sent in three different header
+// There are two supported formats that can be sent in four different header
 // fields:
+//  0. Authorization: LSAT <macBase64>:<preimageHex>
 //  1. Authorization: L402 <macBase64>:<preimageHex>
 //  2. Grpc-Metadata-Macaroon: <macHex>
 //  3. Macaroon: <macHex>
@@ -49,21 +51,27 @@ func FromHeader(header *http.Header) (*macaroon.Macaroon, lntypes.Preimage, erro
 	case header.Get(HeaderAuthorization) != "":
 		// Parse the content of the header field and check that it is in
 		// the correct format.
-		authHeader = header.Get(HeaderAuthorization)
-		log.Debugf("Trying to authorize with header value [%s].",
-			authHeader)
-		if !authRegex.MatchString(authHeader) {
-			return nil, lntypes.Preimage{}, fmt.Errorf("invalid "+
-				"auth header format: %s", authHeader)
+		var matches []string
+		authHeaders := header.Values(HeaderAuthorization)
+		for _, authHeader := range authHeaders {
+			log.Debugf("Trying to authorize with header value "+
+				"[%s].", authHeader)
+			if !authRegex.MatchString(authHeader) {
+				continue
+			}
+			matches = authRegex.FindStringSubmatch(authHeader)
+			if len(matches) != 4 {
+				continue
+			}
 		}
-		matches := authRegex.FindStringSubmatch(authHeader)
-		if len(matches) != 3 {
+
+		if len(matches) != 4 {
 			return nil, lntypes.Preimage{}, fmt.Errorf("invalid "+
 				"auth header format: %s", authHeader)
 		}
 
 		// Decode the content of the two parts of the header value.
-		macBase64, preimageHex := matches[1], matches[2]
+		macBase64, preimageHex := matches[2], matches[3]
 		macBytes, err := base64.StdEncoding.DecodeString(macBase64)
 		if err != nil {
 			return nil, lntypes.Preimage{}, fmt.Errorf("base64 "+
@@ -134,10 +142,17 @@ func SetHeader(header *http.Header, mac *macaroon.Macaroon,
 	if err != nil {
 		return err
 	}
-	value := fmt.Sprintf(
-		authFormat, base64.StdEncoding.EncodeToString(macBytes),
-		preimage.String(),
-	)
-	header.Set(HeaderAuthorization, value)
+	macStr := base64.StdEncoding.EncodeToString(macBytes)
+	preimageStr := preimage.String()
+
+	// Send "Authorization: LSAT..." header before sending
+	// "Authorization: L402" header to be compatible with old aperture.
+	// TODO: remove this after aperture is upgraded everywhere.
+	legacyValue := fmt.Sprintf(authFormatLegacy, macStr, preimageStr)
+	header.Set(HeaderAuthorization, legacyValue)
+
+	value := fmt.Sprintf(authFormat, macStr, preimageStr)
+	header.Add(HeaderAuthorization, value)
+
 	return nil
 }

--- a/l402/identifier.go
+++ b/l402/identifier.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"encoding/binary"
@@ -11,14 +11,14 @@ import (
 )
 
 const (
-	// LatestVersion is the latest version used for minting new LSATs.
+	// LatestVersion is the latest version used for minting new L402s.
 	LatestVersion = 0
 
-	// SecretSize is the size in bytes of a LSAT's secret, also known as
+	// SecretSize is the size in bytes of a L402's secret, also known as
 	// the root key of the macaroon.
 	SecretSize = 32
 
-	// TokenIDSize is the size in bytes of an LSAT's ID encoded in its
+	// TokenIDSize is the size in bytes of an L402's ID encoded in its
 	// macaroon identifier.
 	TokenIDSize = 32
 )
@@ -29,11 +29,11 @@ var (
 	byteOrder = binary.BigEndian
 
 	// ErrUnknownVersion is an error returned when attempting to decode an
-	// LSAT identifier with an unknown version.
-	ErrUnknownVersion = errors.New("unknown LSAT version")
+	// L402 identifier with an unknown version.
+	ErrUnknownVersion = errors.New("unknown L402 version")
 )
 
-// TokenID is the type that stores the token identifier of an LSAT token.
+// TokenID is the type that stores the token identifier of an L402 token.
 type TokenID [TokenIDSize]byte
 
 // String returns the hex encoded representation of the token ID as a string.
@@ -58,24 +58,24 @@ func MakeIDFromString(newID string) (TokenID, error) {
 	return id, nil
 }
 
-// Identifier contains the static identifying details of an LSAT. This is
-// intended to be used as the identifier of the macaroon within an LSAT.
+// Identifier contains the static identifying details of an L402. This is
+// intended to be used as the identifier of the macaroon within an L402.
 type Identifier struct {
-	// Version is the version of an LSAT. Having a version allows us to
+	// Version is the version of an L402. Having a version allows us to
 	// introduce new fields to the identifier in a backwards-compatible
 	// manner.
 	Version uint16
 
-	// PaymentHash is the payment hash linked to an LSAT. Verification of
-	// an LSAT depends on a valid payment, which is enforced by ensuring a
+	// PaymentHash is the payment hash linked to an L402. Verification of
+	// an L402 depends on a valid payment, which is enforced by ensuring a
 	// preimage is provided that hashes to our payment hash.
 	PaymentHash lntypes.Hash
 
-	// TokenID is the unique identifier of an LSAT.
+	// TokenID is the unique identifier of an L402.
 	TokenID TokenID
 }
 
-// EncodeIdentifier encodes an LSAT's identifier according to its version.
+// EncodeIdentifier encodes an L402's identifier according to its version.
 func EncodeIdentifier(w io.Writer, id *Identifier) error {
 	if err := binary.Write(w, byteOrder, id.Version); err != nil {
 		return err
@@ -96,7 +96,7 @@ func EncodeIdentifier(w io.Writer, id *Identifier) error {
 	}
 }
 
-// DecodeIdentifier decodes an LSAT's identifier according to its version.
+// DecodeIdentifier decodes an L402's identifier according to its version.
 func DecodeIdentifier(r io.Reader) (*Identifier, error) {
 	var version uint16
 	if err := binary.Read(r, byteOrder, &version); err != nil {

--- a/l402/identifier_test.go
+++ b/l402/identifier_test.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"bytes"

--- a/l402/log.go
+++ b/l402/log.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Subsystem defines the sub system name of this package.
-const Subsystem = "LSAT"
+const Subsystem = "L402"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller

--- a/l402/log.go
+++ b/l402/log.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"github.com/btcsuite/btclog"

--- a/l402/satisfier.go
+++ b/l402/satisfier.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"fmt"
@@ -18,19 +18,19 @@ type Satisfier struct {
 	// condition can be used multiple times as long as they enforce more
 	// permissions than the previous.
 	//
-	// For example, we have a caveat that only allows us to use an LSAT for
+	// For example, we have a caveat that only allows us to use an L402 for
 	// 7 more days. We can add another caveat that only allows for 3 more
 	// days of use and lend it to another party.
 	SatisfyPrevious func(previous Caveat, current Caveat) error
 
-	// SatisfyFinal satisfies the final caveat of an LSAT. If multiple
+	// SatisfyFinal satisfies the final caveat of an L402. If multiple
 	// caveats with the same condition exist, this will only be executed
 	// once all previous caveats are also satisfied.
 	SatisfyFinal func(Caveat) error
 }
 
 // NewServicesSatisfier implements a satisfier to determine whether the target
-// service is authorized for a given LSAT.
+// service is authorized for a given L402.
 //
 // TODO(wilmer): Add tier verification?
 func NewServicesSatisfier(targetService string) Satisfier {
@@ -80,7 +80,7 @@ func NewServicesSatisfier(targetService string) Satisfier {
 }
 
 // NewCapabilitiesSatisfier implements a satisfier to determine whether the
-// target capability for a service is authorized for a given LSAT.
+// target capability for a service is authorized for a given L402.
 func NewCapabilitiesSatisfier(service string,
 	targetCapability string) Satisfier {
 
@@ -120,7 +120,7 @@ func NewCapabilitiesSatisfier(service string,
 	}
 }
 
-// NewTimeoutSatisfier checks if an LSAT is expired or not. The Satisfier takes
+// NewTimeoutSatisfier checks if an L402 is expired or not. The Satisfier takes
 // a service name to set as the condition prefix and currentTimestamp to
 // compare against the expiration(s) in the caveats. The expiration time is
 // retrieved from the caveat values themselves. The satisfier will also make
@@ -174,7 +174,7 @@ func NewTimeoutSatisfier(service string, now func() time.Time) Satisfier {
 			}
 
 			return fmt.Errorf("not authorized to access " +
-				"service. LSAT has expired")
+				"service. L402 has expired")
 		},
 	}
 }

--- a/l402/satisfier_test.go
+++ b/l402/satisfier_test.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"fmt"

--- a/l402/server_interceptor.go
+++ b/l402/server_interceptor.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"bytes"
@@ -11,11 +11,11 @@ import (
 )
 
 // ServerInterceptor is a gRPC server interceptor that extracts the token ID
-// from the request context if an LSAT is present.
+// from the request context if an L402 is present.
 type ServerInterceptor struct{}
 
 // UnaryInterceptor is an unary gRPC server interceptor that inspects incoming
-// calls for authentication tokens. If an LSAT authentication token is found in
+// calls for authentication tokens. If an L402 authentication token is found in
 // the request, its token ID is extracted and treated as client ID. The
 // extracted ID is then attached to the request context in a format that is easy
 // to extract by request handlers.
@@ -53,7 +53,7 @@ func (w *wrappedStream) Context() context.Context {
 }
 
 // StreamInterceptor is an stream gRPC server interceptor that inspects incoming
-// streams for authentication tokens. If an LSAT authentication token is found
+// streams for authentication tokens. If an L402 authentication token is found
 // in the initial stream establishment request, its token ID is extracted and
 // treated as client ID. The extracted ID is then attached to the request
 // context in a format that is easy to extract by request handlers.
@@ -81,7 +81,7 @@ func (i *ServerInterceptor) StreamInterceptor(srv interface{},
 	return handler(srv, wrappedStream)
 }
 
-// tokenFromContext tries to extract the LSAT from a context.
+// tokenFromContext tries to extract the L402 from a context.
 func tokenFromContext(ctx context.Context) (*TokenID, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -97,7 +97,7 @@ func tokenFromContext(ctx context.Context) (*TokenID, error) {
 		return nil, fmt.Errorf("auth header extraction failed: %v", err)
 	}
 
-	// If there is an LSAT, decode and add it to the context.
+	// If there is an L402, decode and add it to the context.
 	identifier, err := DecodeIdentifier(bytes.NewBuffer(macaroon.Id()))
 	if err != nil {
 		return nil, fmt.Errorf("token ID decoding failed: %v", err)

--- a/l402/service.go
+++ b/l402/service.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"errors"
@@ -33,26 +33,26 @@ var (
 		"\"name:tier\"")
 )
 
-// ServiceTier represents the different possible tiers of an LSAT-enabled
+// ServiceTier represents the different possible tiers of an L402-enabled
 // service.
 type ServiceTier uint8
 
 const (
-	// BaseTier is the base tier of an LSAT-enabled service. This tier
-	// should be used for any new LSATs that are not part of a service tier
+	// BaseTier is the base tier of an L402-enabled service. This tier
+	// should be used for any new L402s that are not part of a service tier
 	// upgrade.
 	BaseTier ServiceTier = iota
 )
 
-// Service contains the details of an LSAT-enabled service.
+// Service contains the details of an L402-enabled service.
 type Service struct {
-	// Name is the name of the LSAT-enabled service.
+	// Name is the name of the L402-enabled service.
 	Name string
 
-	// Tier is the tier of the LSAT-enabled service.
+	// Tier is the tier of the L402-enabled service.
 	Tier ServiceTier
 
-	// Price of service LSAT in satoshis.
+	// Price of service L402 in satoshis.
 	Price int64
 }
 

--- a/l402/service_test.go
+++ b/l402/service_test.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"errors"

--- a/l402/store.go
+++ b/l402/store.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"errors"
@@ -15,11 +15,11 @@ var (
 
 	// storeFileName is the name of the file where we store the final,
 	// valid, token to.
-	storeFileName = "lsat.token"
+	storeFileName = "l402.token"
 
 	// storeFileNamePending is the name of the file where we store a pending
 	// token until it was successfully paid for.
-	storeFileNamePending = "lsat.token.pending"
+	storeFileNamePending = "l402.token.pending"
 
 	// errNoReplace is the error that is returned if a new token is
 	// being written to a store that already contains a paid token.
@@ -27,7 +27,7 @@ var (
 		"new token. " + manualRetryHint)
 )
 
-// Store is an interface that allows users to store and retrieve an LSAT token.
+// Store is an interface that allows users to store and retrieve an L402 token.
 type Store interface {
 	// CurrentToken returns the token that is currently contained in the
 	// store or an error if there is none.

--- a/l402/store_test.go
+++ b/l402/store_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
 )
 
-// TestStore tests the basic functionality of the file based store.
+// TestFileStore tests the basic functionality of the file based store.
 func TestFileStore(t *testing.T) {
 	t.Parallel()
 
@@ -127,4 +128,72 @@ func TestFileStore(t *testing.T) {
 		t.Fatalf("unexpected error. got %v, expected %v", err,
 			errNoReplace)
 	}
+}
+
+// TestFileStorePendingMigration tests migration from lsat.token.pending
+// to l402.token.pending.
+func TestFileStorePendingMigration(t *testing.T) {
+	t.Parallel()
+
+	tempDirName := t.TempDir()
+
+	pendingToken := &Token{
+		Preimage: zeroPreimage,
+		baseMac:  makeMac(),
+	}
+
+	store, err := NewFileStore(tempDirName)
+	require.NoError(t, err)
+
+	// Write a pending token.
+	require.NoError(t, store.StoreToken(pendingToken))
+
+	// Rename file on disk to lsat.token.pending to emulate
+	// a pre-migration state.
+	newPath := filepath.Join(tempDirName, storeFileNamePending)
+	oldPath := filepath.Join(tempDirName, "lsat.token.pending")
+	require.NoError(t, os.Rename(newPath, oldPath))
+
+	// Open the same directory again.
+	store1, err := NewFileStore(tempDirName)
+	require.NoError(t, err)
+
+	// Read the token and compare its value.
+	token, err := store1.CurrentToken()
+	require.NoError(t, err)
+	require.Equal(t, pendingToken.baseMac, token.baseMac)
+}
+
+// TestFileStoreMigration tests migration from lsat.token to l402.token.
+func TestFileStoreMigration(t *testing.T) {
+	t.Parallel()
+
+	tempDirName := t.TempDir()
+
+	paidPreimage := lntypes.Preimage{1, 2, 3, 4, 5}
+	paidToken := &Token{
+		Preimage: paidPreimage,
+		baseMac:  makeMac(),
+	}
+
+	store, err := NewFileStore(tempDirName)
+	require.NoError(t, err)
+
+	// Write a token.
+	require.NoError(t, store.StoreToken(paidToken))
+
+	// Rename file on disk to lsat.token.pending to emulate
+	// a pre-migration state.
+	newPath := filepath.Join(tempDirName, storeFileName)
+	oldPath := filepath.Join(tempDirName, "lsat.token")
+	require.NoError(t, os.Rename(newPath, oldPath))
+
+	// Open the same directory again.
+	store1, err := NewFileStore(tempDirName)
+	require.NoError(t, err)
+
+	// Read the token and compare its value.
+	token, err := store1.CurrentToken()
+	require.NoError(t, err)
+	require.Equal(t, paidToken.baseMac, token.baseMac)
 }

--- a/l402/store_test.go
+++ b/l402/store_test.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"os"
@@ -12,7 +12,7 @@ import (
 func TestFileStore(t *testing.T) {
 	t.Parallel()
 
-	tempDirName, err := os.MkdirTemp("", "lsatstore")
+	tempDirName, err := os.MkdirTemp("", "l402store")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/l402/token.go
+++ b/l402/token.go
@@ -1,4 +1,4 @@
-package lsat
+package l402
 
 import (
 	"bytes"
@@ -17,9 +17,9 @@ var (
 	zeroPreimage lntypes.Preimage
 )
 
-// Token is the main type to store an LSAT token in.
+// Token is the main type to store an L402 token in.
 type Token struct {
-	// PaymentHash is the hash of the LSAT invoice that needs to be paid.
+	// PaymentHash is the hash of the L402 invoice that needs to be paid.
 	// Knowing the preimage to this hash is seen as proof of payment by the
 	// authentication server.
 	PaymentHash lntypes.Hash
@@ -47,7 +47,7 @@ type Token struct {
 }
 
 // tokenFromChallenge parses the parts that are present in the challenge part
-// of the LSAT auth protocol which is the macaroon and the payment hash.
+// of the L402 auth protocol which is the macaroon and the payment hash.
 func tokenFromChallenge(baseMac []byte, paymentHash *[32]byte) (*Token, error) {
 	// First, validate that the macaroon is valid and can be unmarshaled.
 	mac := &macaroon.Macaroon{}
@@ -92,11 +92,11 @@ func (t *Token) PaidMacaroon() (*macaroon.Macaroon, error) {
 // yet expired.
 func (t *Token) IsValid() bool {
 	// TODO(guggero): Extract and validate from caveat once we add an
-	//  expiration date to the LSAT.
+	//  expiration date to the L402.
 	return true
 }
 
-// isPending returns true if the payment for the LSAT is still in flight and we
+// isPending returns true if the payment for the L402 is still in flight and we
 // haven't received the preimage yet.
 func (t *Token) isPending() bool {
 	return t.Preimage == zeroPreimage

--- a/log.go
+++ b/log.go
@@ -3,7 +3,7 @@ package aperture
 import (
 	"github.com/btcsuite/btclog"
 	"github.com/lightninglabs/aperture/auth"
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/proxy"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd"
@@ -27,7 +27,7 @@ func SetupLoggers(root *build.RotatingLogWriter, intercept signal.Interceptor) {
 
 	lnd.SetSubLogger(root, Subsystem, log)
 	lnd.AddSubLogger(root, auth.Subsystem, intercept, auth.UseLogger)
-	lnd.AddSubLogger(root, lsat.Subsystem, intercept, lsat.UseLogger)
+	lnd.AddSubLogger(root, l402.Subsystem, intercept, l402.UseLogger)
 	lnd.AddSubLogger(root, proxy.Subsystem, intercept, proxy.UseLogger)
 	lnd.AddSubLogger(root, "LNDC", intercept, lndclient.UseLogger)
 }

--- a/mint/mint_test.go
+++ b/mint/mint_test.go
@@ -7,21 +7,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/macaroon.v2"
 )
 
 var (
-	testService = lsat.Service{
+	testService = l402.Service{
 		Name: "lightning_loop",
-		Tier: lsat.BaseTier,
+		Tier: l402.BaseTier,
 	}
 )
 
-// TestBasicLSAT ensures that an LSAT can only access the services it's
+// TestBasicL402 ensures that an L402 can only access the services it's
 // authorized to.
-func TestBasicLSAT(t *testing.T) {
+func TestBasicL402(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -32,10 +32,10 @@ func TestBasicLSAT(t *testing.T) {
 		Now:            time.Now,
 	})
 
-	// Mint a basic LSAT which is only able to access the given service.
-	macaroon, _, err := mint.MintLSAT(ctx, testService)
+	// Mint a basic L402 which is only able to access the given service.
+	macaroon, _, err := mint.MintL402(ctx, testService)
 	if err != nil {
-		t.Fatalf("unable to mint LSAT: %v", err)
+		t.Fatalf("unable to mint L402: %v", err)
 	}
 
 	params := VerificationParams{
@@ -43,22 +43,22 @@ func TestBasicLSAT(t *testing.T) {
 		Preimage:      testPreimage,
 		TargetService: testService.Name,
 	}
-	if err := mint.VerifyLSAT(ctx, &params); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, &params); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
 
 	// It should not be able to access an unknown service.
 	unknownParams := params
 	unknownParams.TargetService = "unknown"
-	err = mint.VerifyLSAT(ctx, &unknownParams)
+	err = mint.VerifyL402(ctx, &unknownParams)
 	if !strings.Contains(err.Error(), "not authorized") {
-		t.Fatal("expected LSAT to not be authorized")
+		t.Fatal("expected L402 to not be authorized")
 	}
 }
 
-// TestAdminLSAT ensures that an admin LSAT (one without a services caveat) is
+// TestAdminL402 ensures that an admin L402 (one without a services caveat) is
 // authorized to access any service.
-func TestAdminLSAT(t *testing.T) {
+func TestAdminL402(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -69,10 +69,10 @@ func TestAdminLSAT(t *testing.T) {
 		Now:            time.Now,
 	})
 
-	// Mint an admin LSAT by not including any services.
-	macaroon, _, err := mint.MintLSAT(ctx)
+	// Mint an admin L402 by not including any services.
+	macaroon, _, err := mint.MintL402(ctx)
 	if err != nil {
-		t.Fatalf("unable to mint LSAT: %v", err)
+		t.Fatalf("unable to mint L402: %v", err)
 	}
 
 	// It should be able to access any service as it doesn't have a services
@@ -82,13 +82,13 @@ func TestAdminLSAT(t *testing.T) {
 		Preimage:      testPreimage,
 		TargetService: testService.Name,
 	}
-	if err := mint.VerifyLSAT(ctx, params); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, params); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
 }
 
-// TestRevokedLSAT ensures that we can no longer verify a revoked LSAT.
-func TestRevokedLSAT(t *testing.T) {
+// TestRevokedL402 ensures that we can no longer verify a revoked L402.
+func TestRevokedL402(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -99,33 +99,33 @@ func TestRevokedLSAT(t *testing.T) {
 		Now:            time.Now,
 	})
 
-	// Mint an LSAT and verify it.
-	lsat, _, err := mint.MintLSAT(ctx)
+	// Mint an L402 and verify it.
+	l402, _, err := mint.MintL402(ctx)
 	if err != nil {
-		t.Fatalf("unable to mint LSAT: %v", err)
+		t.Fatalf("unable to mint L402: %v", err)
 	}
 	params := &VerificationParams{
-		Macaroon:      lsat,
+		Macaroon:      l402,
 		Preimage:      testPreimage,
 		TargetService: testService.Name,
 	}
-	if err := mint.VerifyLSAT(ctx, params); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, params); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
 
 	// Proceed to revoke it. We should no longer be able to verify it after.
-	idHash := sha256.Sum256(lsat.Id())
+	idHash := sha256.Sum256(l402.Id())
 	if err := mint.cfg.Secrets.RevokeSecret(ctx, idHash); err != nil {
-		t.Fatalf("unable to revoke LSAT: %v", err)
+		t.Fatalf("unable to revoke L402: %v", err)
 	}
-	if err := mint.VerifyLSAT(ctx, params); err != ErrSecretNotFound {
+	if err := mint.VerifyL402(ctx, params); err != ErrSecretNotFound {
 		t.Fatalf("expected ErrSecretNotFound, got %v", err)
 	}
 }
 
-// TestTamperedLSAT ensures that an LSAT that has been tampered with by
+// TestTamperedL402 ensures that an L402 that has been tampered with by
 // modifying its signature results in its verification failing.
-func TestTamperedLSAT(t *testing.T) {
+func TestTamperedL402(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -136,21 +136,21 @@ func TestTamperedLSAT(t *testing.T) {
 		Now:            time.Now,
 	})
 
-	// Mint a new LSAT and verify it is valid.
-	mac, _, err := mint.MintLSAT(ctx, testService)
+	// Mint a new L402 and verify it is valid.
+	mac, _, err := mint.MintL402(ctx, testService)
 	if err != nil {
-		t.Fatalf("unable to mint LSAT: %v", err)
+		t.Fatalf("unable to mint L402: %v", err)
 	}
 	params := VerificationParams{
 		Macaroon:      mac,
 		Preimage:      testPreimage,
 		TargetService: testService.Name,
 	}
-	if err := mint.VerifyLSAT(ctx, &params); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, &params); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
 
-	// Create a tampered LSAT from the valid one.
+	// Create a tampered L402 from the valid one.
 	macBytes, err := mac.MarshalBinary()
 	if err != nil {
 		t.Fatalf("unable to serialize macaroon: %v", err)
@@ -161,19 +161,19 @@ func TestTamperedLSAT(t *testing.T) {
 		t.Fatalf("unable to deserialize macaroon: %v", err)
 	}
 
-	// Attempting to verify the tampered LSAT should fail.
+	// Attempting to verify the tampered L402 should fail.
 	tamperedParams := params
 	tamperedParams.Macaroon = &tampered
-	err = mint.VerifyLSAT(ctx, &tamperedParams)
+	err = mint.VerifyL402(ctx, &tamperedParams)
 	if !strings.Contains(err.Error(), "signature mismatch") {
-		t.Fatal("expected tampered LSAT to be invalid")
+		t.Fatal("expected tampered L402 to be invalid")
 	}
 }
 
-// TestDemotedServicesLSAT ensures that an LSAT which originally was authorized
+// TestDemotedServicesL402 ensures that an L402 which originally was authorized
 // to access a service, but was then demoted to no longer be the case, is no
 // longer authorized.
-func TestDemotedServicesLSAT(t *testing.T) {
+func TestDemotedServicesL402(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -187,11 +187,11 @@ func TestDemotedServicesLSAT(t *testing.T) {
 	unauthorizedService := testService
 	unauthorizedService.Name = "unauthorized"
 
-	// Mint an LSAT that is able to access two services, one of which will
+	// Mint an L402 that is able to access two services, one of which will
 	// be denied later on.
-	mac, _, err := mint.MintLSAT(ctx, testService, unauthorizedService)
+	mac, _, err := mint.MintL402(ctx, testService, unauthorizedService)
 	if err != nil {
-		t.Fatalf("unable to mint LSAT: %v", err)
+		t.Fatalf("unable to mint L402: %v", err)
 	}
 
 	// It should be able to access both services.
@@ -200,41 +200,41 @@ func TestDemotedServicesLSAT(t *testing.T) {
 		Preimage:      testPreimage,
 		TargetService: testService.Name,
 	}
-	if err := mint.VerifyLSAT(ctx, &authorizedParams); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, &authorizedParams); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
 	unauthorizedParams := VerificationParams{
 		Macaroon:      mac,
 		Preimage:      testPreimage,
 		TargetService: unauthorizedService.Name,
 	}
-	if err := mint.VerifyLSAT(ctx, &unauthorizedParams); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, &unauthorizedParams); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
 
 	// Demote the second service by including an additional services caveat
 	// that only includes the first service.
-	services, err := lsat.NewServicesCaveat(testService)
+	services, err := l402.NewServicesCaveat(testService)
 	if err != nil {
 		t.Fatalf("unable to create services caveat: %v", err)
 	}
-	err = lsat.AddFirstPartyCaveats(mac, services)
+	err = l402.AddFirstPartyCaveats(mac, services)
 	if err != nil {
-		t.Fatalf("unable to demote LSAT: %v", err)
+		t.Fatalf("unable to demote L402: %v", err)
 	}
 
 	// It should now only be able to access the first, but not the second.
-	if err := mint.VerifyLSAT(ctx, &authorizedParams); err != nil {
-		t.Fatalf("unable to verify LSAT: %v", err)
+	if err := mint.VerifyL402(ctx, &authorizedParams); err != nil {
+		t.Fatalf("unable to verify L402: %v", err)
 	}
-	err = mint.VerifyLSAT(ctx, &unauthorizedParams)
+	err = mint.VerifyL402(ctx, &unauthorizedParams)
 	if !strings.Contains(err.Error(), "not authorized") {
 		t.Fatal("expected macaroon to be invalid")
 	}
 }
 
-// TestExpiredServicesLSAT asserts the behavior of the Timeout caveat.
-func TestExpiredServicesLSAT(t *testing.T) {
+// TestExpiredServicesL402 asserts the behavior of the Timeout caveat.
+func TestExpiredServicesL402(t *testing.T) {
 	t.Parallel()
 
 	initialTime := int64(1000)
@@ -248,8 +248,8 @@ func TestExpiredServicesLSAT(t *testing.T) {
 		Now:            mockTime.now,
 	})
 
-	// Mint a new lsat for accessing a test service.
-	mac, _, err := mint.MintLSAT(ctx, testService)
+	// Mint a new l402 for accessing a test service.
+	mac, _, err := mint.MintL402(ctx, testService)
 	require.NoError(t, err)
 
 	authorizedParams := VerificationParams{
@@ -259,22 +259,22 @@ func TestExpiredServicesLSAT(t *testing.T) {
 	}
 
 	// It should be able to access the service if no timeout caveat added.
-	require.NoError(t, mint.VerifyLSAT(ctx, &authorizedParams))
+	require.NoError(t, mint.VerifyL402(ctx, &authorizedParams))
 
 	// Add a timeout caveat that expires in the future.
-	timeout := lsat.NewTimeoutCaveat(testService.Name, 1000, mockTime.now)
-	require.NoError(t, lsat.AddFirstPartyCaveats(mac, timeout))
+	timeout := l402.NewTimeoutCaveat(testService.Name, 1000, mockTime.now)
+	require.NoError(t, l402.AddFirstPartyCaveats(mac, timeout))
 
-	// Make sure that the LSAT is still valid after timeout is added since
+	// Make sure that the L402 is still valid after timeout is added since
 	// the timeout has not yet been reached.
-	require.NoError(t, mint.VerifyLSAT(ctx, &authorizedParams))
+	require.NoError(t, mint.VerifyL402(ctx, &authorizedParams))
 
-	// Force time to pass such that the LSAT should no longer be valid.
+	// Force time to pass such that the L402 should no longer be valid.
 	mockTime.setTime(initialTime + 1001)
 
-	// Assert that the LSAT is no longer valid due to the timeout being
+	// Assert that the L402 is no longer valid due to the timeout being
 	// reached.
-	err = mint.VerifyLSAT(ctx, &authorizedParams)
+	err = mint.VerifyL402(ctx, &authorizedParams)
 	require.Contains(t, err.Error(), "not authorized")
 }
 

--- a/mint/mock_test.go
+++ b/mint/mock_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -41,15 +41,15 @@ func (d *mockChallenger) NewChallenge(price int64) (string, lntypes.Hash,
 }
 
 type mockSecretStore struct {
-	secrets map[[sha256.Size]byte][lsat.SecretSize]byte
+	secrets map[[sha256.Size]byte][l402.SecretSize]byte
 }
 
 var _ SecretStore = (*mockSecretStore)(nil)
 
 func (s *mockSecretStore) NewSecret(ctx context.Context,
-	id [sha256.Size]byte) ([lsat.SecretSize]byte, error) {
+	id [sha256.Size]byte) ([l402.SecretSize]byte, error) {
 
-	var secret [lsat.SecretSize]byte
+	var secret [l402.SecretSize]byte
 	if _, err := rand.Read(secret[:]); err != nil {
 		return secret, err
 	}
@@ -58,7 +58,7 @@ func (s *mockSecretStore) NewSecret(ctx context.Context,
 }
 
 func (s *mockSecretStore) GetSecret(ctx context.Context,
-	id [sha256.Size]byte) ([lsat.SecretSize]byte, error) {
+	id [sha256.Size]byte) ([l402.SecretSize]byte, error) {
 
 	secret, ok := s.secrets[id]
 	if !ok {
@@ -76,30 +76,30 @@ func (s *mockSecretStore) RevokeSecret(ctx context.Context,
 
 func newMockSecretStore() *mockSecretStore {
 	return &mockSecretStore{
-		secrets: make(map[[sha256.Size]byte][lsat.SecretSize]byte),
+		secrets: make(map[[sha256.Size]byte][l402.SecretSize]byte),
 	}
 }
 
 type mockServiceLimiter struct {
-	capabilities map[lsat.Service]lsat.Caveat
-	constraints  map[lsat.Service][]lsat.Caveat
-	timeouts     map[lsat.Service]lsat.Caveat
+	capabilities map[l402.Service]l402.Caveat
+	constraints  map[l402.Service][]l402.Caveat
+	timeouts     map[l402.Service]l402.Caveat
 }
 
 var _ ServiceLimiter = (*mockServiceLimiter)(nil)
 
 func newMockServiceLimiter() *mockServiceLimiter {
 	return &mockServiceLimiter{
-		capabilities: make(map[lsat.Service]lsat.Caveat),
-		constraints:  make(map[lsat.Service][]lsat.Caveat),
-		timeouts:     make(map[lsat.Service]lsat.Caveat),
+		capabilities: make(map[l402.Service]l402.Caveat),
+		constraints:  make(map[l402.Service][]l402.Caveat),
+		timeouts:     make(map[l402.Service]l402.Caveat),
 	}
 }
 
 func (l *mockServiceLimiter) ServiceCapabilities(ctx context.Context,
-	services ...lsat.Service) ([]lsat.Caveat, error) {
+	services ...l402.Service) ([]l402.Caveat, error) {
 
-	res := make([]lsat.Caveat, 0, len(services))
+	res := make([]l402.Caveat, 0, len(services))
 	for _, service := range services {
 		capabilities, ok := l.capabilities[service]
 		if !ok {
@@ -111,9 +111,9 @@ func (l *mockServiceLimiter) ServiceCapabilities(ctx context.Context,
 }
 
 func (l *mockServiceLimiter) ServiceConstraints(ctx context.Context,
-	services ...lsat.Service) ([]lsat.Caveat, error) {
+	services ...l402.Service) ([]l402.Caveat, error) {
 
-	res := make([]lsat.Caveat, 0, len(services))
+	res := make([]l402.Caveat, 0, len(services))
 	for _, service := range services {
 		constraints, ok := l.constraints[service]
 		if !ok {
@@ -125,9 +125,9 @@ func (l *mockServiceLimiter) ServiceConstraints(ctx context.Context,
 }
 
 func (l *mockServiceLimiter) ServiceTimeouts(ctx context.Context,
-	services ...lsat.Service) ([]lsat.Caveat, error) {
+	services ...l402.Service) ([]l402.Caveat, error) {
 
-	res := make([]lsat.Caveat, 0, len(services))
+	res := make([]l402.Caveat, 0, len(services))
 	for _, service := range services {
 		timeouts, ok := l.timeouts[service]
 		if !ok {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/lightninglabs/aperture/auth"
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"google.golang.org/grpc/codes"
 )
 
@@ -300,12 +300,12 @@ func (p *Proxy) director(req *http.Request) {
 
 		// Make sure we always forward the authorization in the correct/
 		// default format so the backend knows what to do with it.
-		mac, preimage, err := lsat.FromHeader(&req.Header)
+		mac, preimage, err := l402.FromHeader(&req.Header)
 		if err == nil {
 			// It could be that there is no auth information because
 			// none is needed for this particular request. So we
 			// only continue if no error is set.
-			err := lsat.SetHeader(&req.Header, mac, preimage)
+			err := l402.SetHeader(&req.Header, mac, preimage)
 			if err != nil {
 				log.Errorf("could not set header: %v", err)
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -398,8 +398,6 @@ func addCorsHeaders(header http.Header) {
 func (p *Proxy) handlePaymentRequired(w http.ResponseWriter, r *http.Request,
 	serviceName string, servicePrice int64) {
 
-	addCorsHeaders(r.Header)
-
 	header, err := p.authenticator.FreshChallengeHeader(
 		r, serviceName, servicePrice,
 	)
@@ -411,6 +409,8 @@ func (p *Proxy) handlePaymentRequired(w http.ResponseWriter, r *http.Request,
 		)
 		return
 	}
+
+	addCorsHeaders(header)
 
 	for name, value := range header {
 		w.Header().Set(name, value[0])

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -154,7 +154,7 @@ func runHTTPTest(t *testing.T, tc *testCase) {
 	require.Equal(t, "402 Payment Required", resp.Status)
 
 	authHeader := resp.Header.Get("Www-Authenticate")
-	require.Contains(t, authHeader, "LSAT")
+	require.Regexp(t, "(LSAT|L402)", authHeader)
 	_ = resp.Body.Close()
 
 	// Make sure that if we query an URL that is on the whitelist, we don't
@@ -317,10 +317,10 @@ func runGRPCTest(t *testing.T, tc *testCase) {
 		Header: map[string][]string{},
 	}, "", 0)
 	capturedHeader := captureMetadata.Get("WWW-Authenticate")
-	require.Len(t, capturedHeader, 1)
+	require.Len(t, capturedHeader, 2)
 	require.Equal(
-		t, expectedHeaderContent.Get("WWW-Authenticate"),
-		capturedHeader[0],
+		t, expectedHeaderContent.Values("WWW-Authenticate"),
+		capturedHeader,
 	)
 
 	// Make sure that if we query an URL that is on the whitelist, we don't

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/aperture/auth"
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/proxy"
 	proxytest "github.com/lightninglabs/aperture/proxy/testdata"
 	"github.com/lightningnetwork/lnd/cert"
@@ -87,7 +87,7 @@ func (s *helloServer) SayHelloNoAuth(_ context.Context,
 }
 
 // TestProxyHTTP tests that the proxy can forward HTTP requests to a backend
-// service and handle LSAT authentication correctly.
+// service and handle L402 authentication correctly.
 func TestProxyHTTP(t *testing.T) {
 	testCases := []*testCase{{
 		name: "no whitelist",
@@ -108,7 +108,7 @@ func TestProxyHTTP(t *testing.T) {
 }
 
 // TestProxyHTTP tests that the proxy can forward HTTP requests to a backend
-// service and handle LSAT authentication correctly.
+// service and handle L402 authentication correctly.
 func runHTTPTest(t *testing.T, tc *testCase) {
 	// Create a list of services to proxy between.
 	services := []*proxy.Service{{
@@ -196,7 +196,7 @@ func runHTTPTest(t *testing.T, tc *testCase) {
 }
 
 // TestProxyHTTP tests that the proxy can forward gRPC requests to a backend
-// service and handle LSAT authentication correctly.
+// service and handle L402 authentication correctly.
 func TestProxyGRPC(t *testing.T) {
 	testCases := []*testCase{{
 		name: "no whitelist",
@@ -234,7 +234,7 @@ func TestProxyGRPC(t *testing.T) {
 }
 
 // TestProxyHTTP tests that the proxy can forward gRPC requests to a backend
-// service and handle LSAT authentication correctly.
+// service and handle L402 authentication correctly.
 func runGRPCTest(t *testing.T, tc *testCase) {
 	// Since gRPC only really works over TLS, we need to generate a
 	// certificate and key pair first.
@@ -309,9 +309,9 @@ func runGRPCTest(t *testing.T, tc *testCase) {
 		grpc.Trailer(&captureMetadata),
 	)
 	require.Error(t, err)
-	require.True(t, lsat.IsPaymentRequired(err))
+	require.True(t, l402.IsPaymentRequired(err))
 
-	// We expect the WWW-Authenticate header field to be set to an LSAT
+	// We expect the WWW-Authenticate header field to be set to an L402
 	// auth response.
 	expectedHeaderContent, _ := mockAuth.FreshChallengeHeader(&http.Request{
 		Header: map[string][]string{},

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -34,8 +34,8 @@ const (
 // Service generically specifies configuration data for backend services to the
 // Aperture proxy.
 type Service struct {
-	// Name is the name of the LSAT-enabled service.
-	Name string `long:"name" description:"Name of the LSAT-enabled service"`
+	// Name is the name of the L402-enabled service.
+	Name string `long:"name" description:"Name of the L402-enabled service"`
 
 	// TLSCertPath is the optional path to the service's TLS certificate.
 	TLSCertPath string `long:"tlscertpath" description:"Path to the service's TLS certificate"`
@@ -75,7 +75,7 @@ type Service struct {
 	// Timeout is an optional value that indicates in how many seconds the
 	// service's caveat should time out relative to the time of creation. So
 	// if a value of 100 is set, then the timeout will be 100 seconds
-	// after creation of the LSAT.
+	// after creation of the L402.
 	Timeout int64 `long:"timeout" description:"An integer value that indicates the number of seconds until the service access expires"`
 
 	// Capabilities is the list of capabilities authorized for the service
@@ -87,9 +87,9 @@ type Service struct {
 	// correspond to the caveat's condition.
 	Constraints map[string]string `long:"constraints" description:"The service constraints to enforce at the base tier"`
 
-	// Price is the custom LSAT value in satoshis to be used for the
+	// Price is the custom L402 value in satoshis to be used for the
 	// service's endpoint.
-	Price int64 `long:"price" description:"Static LSAT value in satoshis to be used for this service"`
+	Price int64 `long:"price" description:"Static L402 value in satoshis to be used for this service"`
 
 	// DynamicPrice holds the config options needed for initialising
 	// the pricer if a gPRC server is to be used for price data.
@@ -99,7 +99,7 @@ type Service struct {
 	// are matched against the path of the URL of a request. If the request
 	// URL matches any of those regular expressions, the call is treated as
 	// if Auth was set to "off". This allows certain RPC methods to not
-	// require an LSAT token. E.g. the path for a gRPC call looks like this:
+	// require an L402 token. E.g. the path for a gRPC call looks like this:
 	// /package_name.ServiceName/MethodName
 	AuthWhitelistPaths []string `long:"authwhitelistpaths" description:"List of regular expressions for paths that don't require authentication'"`
 
@@ -217,7 +217,7 @@ func prepareServices(services []*Service) error {
 		// satoshi is to be used.
 		switch {
 		case service.Price == 0:
-			log.Debugf("Using default LSAT price of %v satoshis for "+
+			log.Debugf("Using default L402 price of %v satoshis for "+
 				"service %s.", defaultServicePrice, service.Name)
 			service.Price = defaultServicePrice
 		case service.Price < 0:

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -139,11 +139,11 @@ services:
         # but would not have any effect without additional support added.
         "valid_until": 1682483169
       
-    # a caveat will be added that expires the LSAT after this many seconds,
+    # a caveat will be added that expires the L402 after this many seconds,
     # 31557600 = 1 year.
     timeout: 31557600    
 
-    # The LSAT value in satoshis for the service. It is ignored if
+    # The L402 value in satoshis for the service. It is ignored if
     # dynamicprice.enabled is set to true.
     price: 0
 

--- a/secrets.go
+++ b/secrets.go
@@ -8,18 +8,18 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/mint"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 var (
-	// secretsPrefix is the key we'll use to prefix all LSAT identifiers
+	// secretsPrefix is the key we'll use to prefix all L402 identifiers
 	// with when storing secrets in an etcd cluster.
 	secretsPrefix = "secrets"
 )
 
-// idKey returns the full key to store in the database for an LSAT identifier.
+// idKey returns the full key to store in the database for an L402 identifier.
 // The identifier is hex-encoded in order to prevent conflicts with the etcd key
 // delimeter.
 //
@@ -32,7 +32,7 @@ func idKey(id [sha256.Size]byte) string {
 	)
 }
 
-// secretStore is a store of LSAT secrets backed by an etcd cluster.
+// secretStore is a store of L402 secrets backed by an etcd cluster.
 type secretStore struct {
 	*clientv3.Client
 }
@@ -40,7 +40,7 @@ type secretStore struct {
 // A compile-time constraint to ensure secretStore implements mint.SecretStore.
 var _ mint.SecretStore = (*secretStore)(nil)
 
-// newSecretStore instantiates a new LSAT secrets store backed by an etcd
+// newSecretStore instantiates a new L402 secrets store backed by an etcd
 // cluster.
 func newSecretStore(client *clientv3.Client) *secretStore {
 	return &secretStore{Client: client}
@@ -49,9 +49,9 @@ func newSecretStore(client *clientv3.Client) *secretStore {
 // NewSecret creates a new cryptographically random secret which is keyed by the
 // given hash.
 func (s *secretStore) NewSecret(ctx context.Context,
-	id [sha256.Size]byte) ([lsat.SecretSize]byte, error) {
+	id [sha256.Size]byte) ([l402.SecretSize]byte, error) {
 
-	var secret [lsat.SecretSize]byte
+	var secret [l402.SecretSize]byte
 	if _, err := rand.Read(secret[:]); err != nil {
 		return secret, err
 	}
@@ -63,21 +63,21 @@ func (s *secretStore) NewSecret(ctx context.Context,
 // GetSecret returns the cryptographically random secret that corresponds to the
 // given hash. If there is no secret, then mint.ErrSecretNotFound is returned.
 func (s *secretStore) GetSecret(ctx context.Context,
-	id [sha256.Size]byte) ([lsat.SecretSize]byte, error) {
+	id [sha256.Size]byte) ([l402.SecretSize]byte, error) {
 
 	resp, err := s.Get(ctx, idKey(id))
 	if err != nil {
-		return [lsat.SecretSize]byte{}, err
+		return [l402.SecretSize]byte{}, err
 	}
 	if len(resp.Kvs) == 0 {
-		return [lsat.SecretSize]byte{}, mint.ErrSecretNotFound
+		return [l402.SecretSize]byte{}, mint.ErrSecretNotFound
 	}
-	if len(resp.Kvs[0].Value) != lsat.SecretSize {
-		return [lsat.SecretSize]byte{}, fmt.Errorf("invalid secret "+
+	if len(resp.Kvs[0].Value) != l402.SecretSize {
+		return [l402.SecretSize]byte{}, fmt.Errorf("invalid secret "+
 			"size %v", len(resp.Kvs[0].Value))
 	}
 
-	var secret [lsat.SecretSize]byte
+	var secret [l402.SecretSize]byte
 	copy(secret[:], resp.Kvs[0].Value)
 	return secret, nil
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/mint"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -64,7 +64,7 @@ func etcdSetup(t *testing.T) (*clientv3.Client, func()) {
 // identifier exists in the store. If it exists, its value is compared against
 // the expected secret.
 func assertSecretExists(t *testing.T, store *secretStore, id [sha256.Size]byte,
-	expSecret *[lsat.SecretSize]byte) {
+	expSecret *[l402.SecretSize]byte) {
 
 	t.Helper()
 

--- a/services.go
+++ b/services.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/lightninglabs/aperture/lsat"
+	"github.com/lightninglabs/aperture/l402"
 	"github.com/lightninglabs/aperture/mint"
 	"github.com/lightninglabs/aperture/proxy"
 )
@@ -13,9 +13,9 @@ import (
 //
 // TODO(wilmer): use etcd instead.
 type staticServiceLimiter struct {
-	capabilities map[lsat.Service]lsat.Caveat
-	constraints  map[lsat.Service][]lsat.Caveat
-	timeouts     map[lsat.Service]lsat.Caveat
+	capabilities map[l402.Service]l402.Caveat
+	constraints  map[l402.Service][]l402.Caveat
+	timeouts     map[l402.Service]l402.Caveat
 }
 
 // A compile-time constraint to ensure staticServiceLimiter implements
@@ -27,30 +27,30 @@ var _ mint.ServiceLimiter = (*staticServiceLimiter)(nil)
 func newStaticServiceLimiter(
 	proxyServices []*proxy.Service) *staticServiceLimiter {
 
-	capabilities := make(map[lsat.Service]lsat.Caveat)
-	constraints := make(map[lsat.Service][]lsat.Caveat)
-	timeouts := make(map[lsat.Service]lsat.Caveat)
+	capabilities := make(map[l402.Service]l402.Caveat)
+	constraints := make(map[l402.Service][]l402.Caveat)
+	timeouts := make(map[l402.Service]l402.Caveat)
 
 	for _, proxyService := range proxyServices {
-		s := lsat.Service{
+		s := l402.Service{
 			Name:  proxyService.Name,
-			Tier:  lsat.BaseTier,
+			Tier:  l402.BaseTier,
 			Price: proxyService.Price,
 		}
 
 		if proxyService.Timeout > 0 {
-			timeouts[s] = lsat.NewTimeoutCaveat(
+			timeouts[s] = l402.NewTimeoutCaveat(
 				proxyService.Name,
 				proxyService.Timeout,
 				time.Now,
 			)
 		}
 
-		capabilities[s] = lsat.NewCapabilitiesCaveat(
+		capabilities[s] = l402.NewCapabilitiesCaveat(
 			proxyService.Name, proxyService.Capabilities,
 		)
 		for cond, value := range proxyService.Constraints {
-			caveat := lsat.Caveat{Condition: cond, Value: value}
+			caveat := l402.Caveat{Condition: cond, Value: value}
 			constraints[s] = append(constraints[s], caveat)
 		}
 	}
@@ -65,9 +65,9 @@ func newStaticServiceLimiter(
 // ServiceCapabilities returns the capabilities caveats for each service. This
 // determines which capabilities of each service can be accessed.
 func (l *staticServiceLimiter) ServiceCapabilities(ctx context.Context,
-	services ...lsat.Service) ([]lsat.Caveat, error) {
+	services ...l402.Service) ([]l402.Caveat, error) {
 
-	res := make([]lsat.Caveat, 0, len(services))
+	res := make([]l402.Caveat, 0, len(services))
 	for _, service := range services {
 		capabilities, ok := l.capabilities[service]
 		if !ok {
@@ -82,9 +82,9 @@ func (l *staticServiceLimiter) ServiceCapabilities(ctx context.Context,
 // ServiceConstraints returns the constraints for each service. This enforces
 // additional constraints on a particular service/service capability.
 func (l *staticServiceLimiter) ServiceConstraints(ctx context.Context,
-	services ...lsat.Service) ([]lsat.Caveat, error) {
+	services ...l402.Service) ([]l402.Caveat, error) {
 
-	res := make([]lsat.Caveat, 0, len(services))
+	res := make([]l402.Caveat, 0, len(services))
 	for _, service := range services {
 		constraints, ok := l.constraints[service]
 		if !ok {
@@ -99,9 +99,9 @@ func (l *staticServiceLimiter) ServiceConstraints(ctx context.Context,
 // ServiceTimeouts returns the timeout caveat for each service. This enforces
 // an expiration time for service access if enabled.
 func (l *staticServiceLimiter) ServiceTimeouts(ctx context.Context,
-	services ...lsat.Service) ([]lsat.Caveat, error) {
+	services ...l402.Service) ([]l402.Caveat, error) {
 
-	res := make([]lsat.Caveat, 0, len(services))
+	res := make([]l402.Caveat, 0, len(services))
 	for _, service := range services {
 		timeout, ok := l.timeouts[service]
 		if !ok {

--- a/static/index.html
+++ b/static/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>LSAT proxy demo page</title>
+    <title>L402 proxy demo page</title>
     <style>
         .row:after {
             content: "";

--- a/static/index.html
+++ b/static/index.html
@@ -53,10 +53,10 @@
   let lastInvoice = null;
 
   function parseInvoice(invoice) {
-    const rex = /LSAT macaroon="(.*?)", invoice="(.*?)"/i;
+    const rex = /(LSAT|L402) macaroon="(.*?)", invoice="(.*?)"/i;
     parts = invoice.match(rex);
-    lastMacaroon = parts[1];
-    lastInvoice = parts[2];
+    lastMacaroon = parts[2];
+    lastInvoice = parts[3];
   }
 
   function loadJSON(url, elem) {
@@ -90,7 +90,7 @@
         .then((provider) => {
           provider.sendPayment(lastInvoice)
             .then((response) => {
-              authorization = "LSAT " + lastMacaroon + ":" + response.preimage;
+              authorization = "L402 " + lastMacaroon + ":" + response.preimage;
               $('#reload-bos').click();
               $('#reload-lnd').click();
             });
@@ -105,7 +105,7 @@
 
   function addPreimage() {
     let preimage = prompt("Enter hex encoded preimage");
-    authorization = "LSAT " + lastMacaroon + ":" + preimage;
+    authorization = "L402 " + lastMacaroon + ":" + preimage;
     $('#reload-bos').click();
     $('#reload-lnd').click();
   }

--- a/static/index.html
+++ b/static/index.html
@@ -83,7 +83,7 @@
       }
     });
   }
-  
+
   function payInvoice() {
     if (window.WebLN) {
       WebLN.requestProvider()
@@ -102,7 +102,7 @@
       alert("Joule not installed or failed to load WebLN library.");
     }
   }
-  
+
   function addPreimage() {
     let preimage = prompt("Enter hex encoded preimage");
     authorization = "LSAT " + lastMacaroon + ":" + preimage;
@@ -112,7 +112,7 @@
 
   $(document).ready(() => {
     const host = document.location.host;
-    
+
     $('#reload-lnd').on('click', () => loadJSON('//alice.' + host + '/v1/getinfo', $('#getinfo-lnd'))).click();
     $('#reload-bos').on('click', () => loadJSON('//' + host + '/availability/v1/btc.json', $('#bos-scores'))).click();
     $('#pay').on('click', () => payInvoice());


### PR DESCRIPTION
LSAT protocol has been renamed to L402.

This PR replaces all occurrences of "LSAT" with "L402" in the codebase.

Notes:

  * The broken link in the README referring the standard's page, now directs to [L402's GitHub repo](https://github.com/lightninglabs/L402)
  * Both the server and the client previously sent `WWW-Authenticate: LSAT macaroon=` and `Authorization: LSAT ...` headers respectively. [The protocol defines](https://github.com/lightninglabs/L402/blob/master/protocol-specification.md#http-specification) that they should both use the L402 auth-scheme instead of LSAT. Now, both of them send two headers: first, the LSAT version they used to send before, then the L402 version of the header. The latter contains the same content, but L402 is used as the auth-scheme instead of LSAT. The reason for preserving LSAT versions of the headers and sending them first is because existing instances of clients and servers check the first instance of a header. After Aperture is upgraded, we can stop sending `Authorization: LSAT ...`, but `WWW-Authenticate: LSAT ...` will remain at least until all currently deployed loop versions reach the end of life.
  * Unrelated fix: don't send the client's headers back. The Aperture server used to take the request's headers as a basis for building response headers. This behavior has been replaced by creating a fresh header set, initially containing just one header, which is required for things to work: `Content-Type: application/grpc`.
  * Unrelated fix: optimized away unnecessary regexp `MatchString` call. It is followed by `FindStringSubmatch` which does the same job and returns `nil` in case nothing matches. This results in the same outcome if the removed `MatchString` call returns false.