### PR TITLE
Accept comma separated macaroons

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -41,11 +41,14 @@ func (l *L402Authenticator) Accept(header *http.Header, serviceName string) bool
 	// Try reading the macaroon and preimage from the HTTP header. This can
 	// be in different header fields depending on the implementation and/or
 	// protocol.
-	mac, preimage, err := l402.FromHeader(header)
+	macs, preimage, err := l402.FromHeader(header)
 	if err != nil {
 		log.Debugf("Deny: %v", err)
 		return false
 	}
+
+	// TODO: Be able to accept multiple macaroons
+	mac := macs[0]
 
 	verificationParams := &mint.VerificationParams{
 		Macaroon:      mac,

--- a/l402/server_interceptor.go
+++ b/l402/server_interceptor.go
@@ -92,10 +92,13 @@ func tokenFromContext(ctx context.Context) (*TokenID, error) {
 	}
 	log.Debugf("Auth header present in request: %s",
 		md.Get(HeaderAuthorization))
-	macaroon, _, err := FromHeader(header)
+	macaroons, _, err := FromHeader(header)
 	if err != nil {
 		return nil, fmt.Errorf("auth header extraction failed: %v", err)
 	}
+
+	// TODO: Be able to accept multiple macaroons
+	macaroon := macaroons[0]
 
 	// If there is an L402, decode and add it to the context.
 	identifier, err := DecodeIdentifier(bytes.NewBuffer(macaroon.Id()))


### PR DESCRIPTION
#143 
This will allow Aperture to receive comma separated macaroons and not reject the request as an error.
If multiple macaroons are received, the first one is used and the others are ignored (for now)
