### PR TITLE
build: upgrade go to v1.23.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,7 @@ env:
 
   # If you change this value, please change it in the following files as well:
   # /Dockerfile
-  #
-  # Don't bump this until go 1.19 is out (which should include a fix for
-  # https://github.com/golang/go/issues/51799). There was a race condition
-  # introduced with go 1.16.10 that causes the unit tests to fail (could also
-  # happen in production).
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.23.1
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine as builder
+FROM golang:1.23.1-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/lightninglabs/aperture
 
-go 1.22.6
-
-toolchain go1.22.7
+go 1.23.1
 
 require (
 	github.com/btcsuite/btcd v0.24.2-beta.rc1.0.20240625142744-cc26860b4026

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.6-bookworm
+FROM golang:1.23.1-bookworm
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/lightninglabs/aperture/tools
 
-go 1.22
-
-toolchain go1.22.3
+go 1.23.1
 
 require (
 	github.com/golangci/golangci-lint v1.55.2


### PR DESCRIPTION
When building `aperture` I'm receiving:
```
4.151 OK: 213 MiB in 51 packages
4.184 Cloning into '/go/src/github.com/lightninglabs/aperture'...
4.843 Already on 'master'
4.843 Your branch is up to date with 'origin/master'.
4.855 go: errors parsing go.mod:
4.855 /go/src/github.com/lightninglabs/aperture/go.mod:3: invalid go version '1.22.6': must match format 1.23
4.855 /go/src/github.com/lightninglabs/aperture/go.mod:5: unknown directive: toolchain
4.857 go install -v github.com/lightninglabs/aperture/cmd/aperture
4.859 go: errors parsing go.mod:
4.859 /go/src/github.com/lightninglabs/aperture/go.mod:3: invalid go version '1.22.6': must match format 1.23
4.859 /go/src/github.com/lightninglabs/aperture/go.mod:5: unknown directive: toolchain
4.859 make: *** [Makefile:61: install] Error 1
------
```

This PR upgrades the `Dockerfile` to use `v1.23.1-alpine`.