### PR TITLE
multi: bump Golang version to fix Docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   # https://github.com/golang/go/issues/51799). There was a race condition
   # introduced with go 1.16.10 that causes the unit tests to fail (could also
   # happen in production).
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.6
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine as builder
+FROM golang:1.22.6-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/lightninglabs/aperture/tools
 
 go 1.22
 
-toolchain go1.22.3
+toolchain go1.22.6
 
 require (
 	github.com/golangci/golangci-lint v1.55.2


### PR DESCRIPTION
Fixes Docker build issues, see https://github.com/lightninglabs/aperture/actions/runs/11976500458/job/33392315413