### PR TITLE
aperture: internally aggregate session statistics to reduce cardinality

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -151,7 +151,7 @@ func run() error {
 
 	errChan := make(chan error)
 	a := NewAperture(cfg)
-	if err := a.Start(errChan); err != nil {
+	if err := a.Start(errChan, interceptor.ShutdownChannel()); err != nil {
 		return fmt.Errorf("unable to start aperture: %v", err)
 	}
 
@@ -192,9 +192,9 @@ func NewAperture(cfg *Config) *Aperture {
 }
 
 // Start sets up the proxy server and starts it.
-func (a *Aperture) Start(errChan chan error) error {
+func (a *Aperture) Start(errChan chan error, shutdown <-chan struct{}) error {
 	// Start the prometheus exporter.
-	err := StartPrometheusExporter(a.cfg.Prometheus)
+	err := StartPrometheusExporter(a.cfg.Prometheus, shutdown)
 	if err != nil {
 		return fmt.Errorf("unable to start the prometheus "+
 			"exporter: %v", err)

--- a/hashmail_server.go
+++ b/hashmail_server.go
@@ -809,9 +809,9 @@ func (sa *streamActivity) Record(baseID string) {
 // ClassifyAndReset categorizes each tracked stream based on its recent read
 // rate and returns aggregate counts of active, standby, and in-use sessions.
 // A stream is classified as:
-// - In-use:   if read rate ≥ 0.5 reads/sec
-// - Standby:  if 0 < read rate < 0.5 reads/sec
-// - Active:   if read rate > 0 (includes standby and in-use)
+// - In-use:   if read rate ≥ 0.5 reads/sec.
+// - Standby:  if 0 < read rate < 0.5 reads/sec.
+// - Active:   if read rate > 0 (includes standby and in-use).
 func (sa *streamActivity) ClassifyAndReset() (active, standby, inuse int) {
 	sa.Lock()
 	defer sa.Unlock()

--- a/hashmail_server_test.go
+++ b/hashmail_server_test.go
@@ -186,7 +186,8 @@ func setupAperture(t *testing.T) {
 	}
 	aperture := NewAperture(apertureCfg)
 	errChan := make(chan error)
-	require.NoError(t, aperture.Start(errChan))
+	shutdown := make(chan struct{})
+	require.NoError(t, aperture.Start(errChan, shutdown))
 
 	// Any error while starting?
 	select {


### PR DESCRIPTION
This PR adds aggregation and classification of sessions into `{active, standby, inuse}` categories and makes direct metrics exportable.

It is an attempt to lower the cardinality of the prior used read count metric. This should greatly reduce the load on Prometheus for both storage and querying.

However, there is a caveat with the code as-is:
* Unbounded memory growth: while the prior approach essentially made it the prometheus server's problem, we now have to deal with this ourselves. Looking for feedback on an appropriate culling threshold. I wanted to first and foremost mimic what we were doing before so I did not implement culling yet.