### PR TITLE
multi: add new strict-verify CLI option to control invoice usage

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -337,7 +337,7 @@ func (a *Aperture) Start(errChan chan error) error {
 
 			a.challenger, err = challenger.NewLNCChallenger(
 				session, lncStore, a.cfg.InvoiceBatchSize,
-				genInvoiceReq, errChan,
+				genInvoiceReq, errChan, a.cfg.StrictVerify,
 			)
 			if err != nil {
 				return fmt.Errorf("unable to start lnc "+
@@ -361,7 +361,7 @@ func (a *Aperture) Start(errChan chan error) error {
 
 			a.challenger, err = challenger.NewLndChallenger(
 				client, a.cfg.InvoiceBatchSize, genInvoiceReq,
-				context.Background, errChan,
+				context.Background, errChan, a.cfg.StrictVerify,
 			)
 			if err != nil {
 				return err

--- a/challenger/lnc.go
+++ b/challenger/lnc.go
@@ -20,7 +20,7 @@ type LNCChallenger struct {
 // connect to an lnd backend to create payment challenges.
 func NewLNCChallenger(session *lnc.Session, lncStore lnc.Store,
 	invoiceBatchSize int, genInvoiceReq InvoiceRequestGenerator,
-	errChan chan<- error) (*LNCChallenger, error) {
+	errChan chan<- error, strictVerify bool) (*LNCChallenger, error) {
 
 	nodeConn, err := lnc.NewNodeConn(session, lncStore)
 	if err != nil {
@@ -35,7 +35,7 @@ func NewLNCChallenger(session *lnc.Session, lncStore lnc.Store,
 
 	lndChallenger, err := NewLndChallenger(
 		client, invoiceBatchSize, genInvoiceReq, nodeConn.CtxFunc,
-		errChan,
+		errChan, strictVerify,
 	)
 	if err != nil {
 		return nil, err

--- a/challenger/lnd_test.go
+++ b/challenger/lnd_test.go
@@ -120,6 +120,7 @@ func newChallenger() (*LndChallenger, *mockInvoiceClient, chan error) {
 		invoicesMtx:   invoicesMtx,
 		invoicesCond:  sync.NewCond(invoicesMtx),
 		errChan:       mainErrChan,
+		strictVerify:  true,
 	}, mockClient, mainErrChan
 }
 
@@ -142,7 +143,7 @@ func TestLndChallenger(t *testing.T) {
 	// First of all, test that the NewLndChallenger doesn't allow a nil
 	// invoice generator function.
 	errChan := make(chan error)
-	_, err := NewLndChallenger(nil, 1, nil, nil, errChan)
+	_, err := NewLndChallenger(nil, 1, nil, nil, errChan, true)
 	require.Error(t, err)
 
 	// Now mock the lnd backend and create a challenger instance that we can

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ var (
 	defaultLogLevel         = "info"
 	defaultLogFilename      = "aperture.log"
 	defaultInvoiceBatchSize = 100000
+	defaultStrictVerify     = false
 
 	defaultSqliteDatabaseFileName = "aperture.db"
 
@@ -224,6 +225,11 @@ type Config struct {
 	// request.
 	InvoiceBatchSize int `long:"invoicebatchsize" description:"The number of invoices to fetch in a single request."`
 
+	// StrictVerify is a flag that indicates whether we should verify the
+	// invoice status strictly or not. If set to true, then this requires
+	// all invoices to be read from disk at start up.
+	StrictVerify bool `long:"strictverify" description:"Whether to verify the invoice status strictly or not."`
+
 	// Logging controls various aspects of aperture logging.
 	Logging *build.LogConfig `group:"logging" namespace:"logging"`
 
@@ -274,5 +280,6 @@ func NewConfig() *Config {
 		InvoiceBatchSize: defaultInvoiceBatchSize,
 		Logging:          build.DefaultLogConfig(),
 		Blocklist:        []string{},
+		StrictVerify:     defaultStrictVerify,
 	}
 }

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -19,6 +19,10 @@ debuglevel: "debug"
 autocert: false
 servername: aperture.example.com
 
+# Whether we should verify the invoice status strictly or not. If set to true,
+# then this requires all invoices to be read from disk at start up.
+strictverify: false
+
 # The port on which the pprof profile will be served. If no port is provided,
 # the profile will not be served.
 profile: 9999

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -14,18 +14,41 @@ servestatic: false
 # Valid options include: trace, debug, info, warn, error, critical, off.
 debuglevel: "debug"
 
+# Custom path to a config file.
+configfile: "/path/to/your/aperture.yaml"
+
+# Directory to place all of aperture's files in.
+basedir: "/path/to/.aperture"
+
 # Whether the proxy should create a valid certificate through Let's Encrypt for
 # the fully qualifying domain name.
 autocert: false
 servername: aperture.example.com
 
+# Whether to listen on an insecure connection, disabling TLS for incoming
+# connections.
+insecure: false
+
 # Whether we should verify the invoice status strictly or not. If set to true,
 # then this requires all invoices to be read from disk at start up.
 strictverify: false
 
+# The number of invoices to fetch in a single request when interacting with LND.
+invoicebatchsize: 100000
+
 # The port on which the pprof profile will be served. If no port is provided,
 # the profile will not be served.
 profile: 9999
+
+# The maximum amount of time a connection may be idle before being closed.
+# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+idletimeout: 2m
+
+# The maximum amount of time to wait for a request to be fully read.
+readtimeout: 15s
+
+# The maximum amount of time to wait for a response to be fully written.
+writetimeout: 30s
 
 # Settings for the lnd node used to generate payment requests. All of these
 # options are required.
@@ -80,6 +103,9 @@ sqlite:
     # The full path to the database.
     dbfile: "/path/to/.aperture/aperture.db"
 
+    # Skip applying migrations on startup.
+    skipmigrations: false
+
 # Settings for the postgres instance which the proxy will use to reliably store 
 # and retrieve token information.
 postgres:
@@ -96,6 +122,9 @@ postgres:
     # Whether to require using SSL (mode: require) when connecting to the 
     # server.
     requireSSL: true
+
+    # Skip applying migrations on startup.
+    skipmigrations: false
 
 # Settings for the etcd instance which the proxy will use to reliably store and
 # retrieve token information.
@@ -228,6 +257,10 @@ hashmail:
   enabled: true
   messagerate: 20ms
   messageburstallowance: 1000
+  
+  # The time after the last activity that a mailbox should be removed.
+  # Set to -1s to disable. Valid time units are "ns", "us", "ms", "s", "m", "h".
+  staletimeout: -1s # Example: 5m for 5 minutes, or -1s to disable
 
 # Enable the prometheus metrics exporter so that a prometheus server can scrape
 # the metrics.
@@ -242,6 +275,14 @@ logging:
     disable: false
     callsite: off
     notimestamps: true
+
+    # Log level for console output.
+    # Valid options include: trace, debug, info, warn, error, critical, off.
+    level: "info"
   file:
     disable: false
     callsite: long
+
+    # Log level for file output.
+    # Valid options include: trace, debug, info, warn, error, critical, off.
+    level: "info"


### PR DESCRIPTION
In this commit, we add a new CLI argument that allows a user to control if we use strict verification or not. Strict verification relies on checking the actual invoice state against lnd, and requires more state for the Aperture server.

When strict verification isn't on, we rely only on the preimage payment hash relationship. Namely that the only way a user can obtain the preimage is to pay the invoice, and as we check the HMAC on the macaroon, we know that we created it with an invoice obtained from lnd.