### PR TITLE
Add Invoice skip list

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -134,6 +134,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If the request is a gRPC request, we need to set the Content-Type
+	// header to application/grpc.
+	if strings.HasPrefix(r.Header.Get(hdrContentType), hdrTypeGrpc) {
+		w.Header().Set(hdrContentType, hdrTypeGrpc)
+	}
+
 	// Requests that can't be matched to a service backend will be
 	// dispatched to the static file server. If the file exists in the
 	// static file folder it will be served, otherwise the static server

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -151,6 +151,17 @@ services:
     # dynamicprice.enabled is set to true.
     price: 0
 
+    # A list of regular expressions for path that are free of charge.
+    authwhitelistpaths:
+      - '^/freebieservice.*$'
+
+    # A list of regular expressions for path that will skip invoice creation,
+    # but still try to do the l402 authentication. This is useful for streaming
+    # services, as they are not supported to be the initial request to receive
+    # a L402.
+    authskipinvoicecreationpaths:
+      - '^/streamingservice.*$'
+
     # Options to use for connection to the price serving gRPC server.
     dynamicprice:
       # Whether or not a gRPC server is available to query price data from. If


### PR DESCRIPTION
This PR adds a new list for the config which will allow skipping the creation of invoices on these specific calls.
This is useful for streaming rpcs, as we can't handle the l402 handshake there (yet?).