### PR TITLE
proxy: precompile regexp

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -366,21 +365,21 @@ func certPool(services []*Service) (*x509.CertPool, error) {
 // expression matching the host and path.
 func matchService(req *http.Request, services []*Service) (*Service, bool) {
 	for _, service := range services {
-		hostRegexp := regexp.MustCompile(service.HostRegexp)
+		hostRegexp := service.compiledHostRegexp
 		if !hostRegexp.MatchString(req.Host) {
 			log.Tracef("Req host [%s] doesn't match [%s].",
 				req.Host, hostRegexp)
 			continue
 		}
 
-		if service.PathRegexp == "" {
+		if service.compiledPathRegexp == nil {
 			log.Debugf("Host [%s] matched pattern [%s] and path "+
 				"expression is empty. Using service [%s].",
 				req.Host, hostRegexp, service.Address)
 			return service, true
 		}
 
-		pathRegexp := regexp.MustCompile(service.PathRegexp)
+		pathRegexp := service.compiledPathRegexp
 		if !pathRegexp.MatchString(req.URL.Path) {
 			log.Tracef("Req path [%s] doesn't match [%s].",
 				req.URL.Path, pathRegexp)


### PR DESCRIPTION
We currently always compile the regular expressions on every intercepted request. This PR changes that by precompiling the regular expressions on service creation/update.

For this benchmark code:
```golang
// BenchmarkRegexpCompiledVSPreCompiled benchmarks the performance of
// compiled vs pre-compiled regexes.
func BenchmarkRegexpCompiledVSPreCompiled(b *testing.B) {
	b.Run("Precompiled", func(b *testing.B) {
		re := regexp.MustCompile(testPathRegexpGRPC)
		for i := 0; i < b.N; i++ {
			_ = re.MatchString("/proxy_test.Greeter/SayHello")
		}
	})

	b.Run("CompiledOnIteration", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			re := regexp.MustCompile(testPathRegexpGRPC)
			_ = re.MatchString("/proxy_test.Greeter/SayHello")
		}
	})
}

```

we get the following result:
```
goos: linux
goarch: amd64
pkg: github.com/lightninglabs/aperture/proxy
cpu: Intel(R) Core(TM) i7-14700K
BenchmarkRegexpCompiledVSPreCompiled
BenchmarkRegexpCompiledVSPreCompiled/Precompiled
BenchmarkRegexpCompiledVSPreCompiled/Precompiled-28         	  632400	      1828 ns/op	      24 B/op	       0 allocs/op
BenchmarkRegexpCompiledVSPreCompiled/CompiledOnIteration
BenchmarkRegexpCompiledVSPreCompiled/CompiledOnIteration-28 	   35544	     33684 ns/op	    7940 B/op	      85 allocs/op
PASS
```
