### PR TITLE
challanger: fix shutdown panic

### DIFF
--- a/challenger/lnd.go
+++ b/challenger/lnd.go
@@ -270,7 +270,9 @@ func (l *LndChallenger) readInvoiceStream(
 
 // Stop shuts down the challenger.
 func (l *LndChallenger) Stop() {
-	l.invoicesCancel()
+	if l.invoicesCancel != nil {
+		l.invoicesCancel()
+	}
 	close(l.quit)
 	l.wg.Wait()
 }


### PR DESCRIPTION
Seeing the following because `l.invoiceCancel()` isn't initialized when config `strictverify` isn't set.
```
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103fcf340]

goroutine 1 [running]:
github.com/lightninglabs/aperture/challenger.(*LndChallenger).Stop(0x140005fbc00)
        /Users/bob/projects/go/src/github.com/aperture/challenger/lnd.go:273 +0x20
```