### PR TITLE
aperture: filter empty TLS SAN hostnames

### DIFF
--- a/aperture_test.go
+++ b/aperture_test.go
@@ -1,0 +1,18 @@
+package aperture
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetTLSConfigAllowsEmptyServerName ensures that generating a default
+// self-signed TLS cert without a server name succeeds. This used to work
+// before Go 1.25 tightened SAN validation, so we rely on Aperture handling it.
+func TestGetTLSConfigAllowsEmptyServerName(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := getTLSConfig("", t.TempDir(), false)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}


### PR DESCRIPTION
Go 1.25 tightened x509 validation and now rejects empty dNSName entries, causing the default self-signed cert generation to fail when ServerName is left unset (`x509: SAN dNSName is malformed`). Filter out empty host names before calling cert.GenCertPair and reuse the same SAN list when renewing, allowing the default config to keep working. Add a unit test that reproduces the failure.