### PR TITLE
hashmail: fix flacky tests

### DIFF
--- a/hashmail_server_test.go
+++ b/hashmail_server_test.go
@@ -512,7 +512,10 @@ func recvFromStream(client hashmailrpc.HashMailClient) error {
 	}()
 
 	select {
-	case <-time.After(time.Second):
+	// Wait a little longer than the server's stream-acquire timeout so we
+	// only trip this path when the server truly failed to hand over the
+	// stream (instead of beating it to the punch).
+	case <-time.After(2 * streamAcquireTimeout):
 		return fmt.Errorf("timed out waiting to receive from receive " +
 			"stream")
 


### PR DESCRIPTION
## Summary
- make `RequestReadStream`/`RequestWriteStream` wait for their respective channels (bounded by `streamAcquireTimeout` and respecting context) instead of immediately returning "stream occupied", removing the race that caused `TestHashMailServerReturnStream` to flake

- ensure `setupAperture` stops its Aperture instance via `t.Cleanup`, so each test tears down its server even when it fails midway; this prevents one test from leaving a live HashMail stream that causes the next test's
  `NewCipherBox` call to hit `AlreadyExists`

## Testing
- `go test -run 'TestHashMailServer(ReturnStream|LargeMessage)' -count=20`