### PR TITLE
aperturedb: add yaml struct tags to fix config file key mismatches

### DIFF
--- a/aperturedb/postgres.go
+++ b/aperturedb/postgres.go
@@ -28,14 +28,14 @@ var (
 
 // PostgresConfig holds the postgres database configuration.
 type PostgresConfig struct {
-	SkipMigrations     bool   `long:"skipmigrations" description:"Skip applying migrations on startup."`
+	SkipMigrations     bool   `long:"skipmigrations" yaml:"skipmigrations" description:"Skip applying migrations on startup."`
 	Host               string `long:"host" description:"Database server hostname."`
 	Port               int    `long:"port" description:"Database server port."`
 	User               string `long:"user" description:"Database user."`
 	Password           string `long:"password" description:"Database user's password."`
 	DBName             string `long:"dbname" description:"Database name to use."`
-	MaxOpenConnections int32  `long:"maxconnections" description:"Max open connections to keep alive to the database server."`
-	RequireSSL         bool   `long:"requiressl" description:"Whether to require using SSL (mode: require) when connecting to the server."`
+	MaxOpenConnections int32  `long:"maxconnections" yaml:"maxconnections" description:"Max open connections to keep alive to the database server."`
+	RequireSSL         bool   `long:"requiressl" yaml:"requireSSL" description:"Whether to require using SSL (mode: require) when connecting to the server."`
 }
 
 // DSN returns the dns to connect to the database.

--- a/aperturedb/sqlite.go
+++ b/aperturedb/sqlite.go
@@ -40,11 +40,11 @@ const (
 type SqliteConfig struct {
 	// SkipMigrations if true, then all the tables will be created on start
 	// up if they don't already exist.
-	SkipMigrations bool `long:"skipmigrations" description:"Skip applying migrations on startup."`
+	SkipMigrations bool `long:"skipmigrations" yaml:"skipmigrations" description:"Skip applying migrations on startup."`
 
 	// DatabaseFileName is the full file path where the database file can be
 	// found.
-	DatabaseFileName string `long:"dbfile" description:"The full path to the database."`
+	DatabaseFileName string `long:"dbfile" yaml:"dbfile" description:"The full path to the database."`
 }
 
 // SqliteStore is a database store implementation that uses a sqlite backend.


### PR DESCRIPTION
## Summary

Adds missing `yaml:` struct tags to `SqliteConfig` and `PostgresConfig` so that YAML config file keys are correctly mapped when aperture is configured via `aperture.yaml`.

### Problem

`goccy/go-yaml` (used in `aperture.go`) falls back to the lowercased field name when no `yaml:` tag is present. This caused silent mismatches:

| Struct field | go-flags key | YAML fallback | sample-conf.yaml key | Result |
|---|---|---|---|---|
| `SqliteConfig.DatabaseFileName` | `dbfile` | `databasefilename` | `dbfile` | **Never read** — SQLite fails to open |
| `SqliteConfig.SkipMigrations` | `skipmigrations` | `skipmigrations` | `skipmigrations` | Coincidental match (no change needed) |
| `PostgresConfig.MaxOpenConnections` | `maxconnections` | `maxopenconnections` | `maxconnections` | **Never read** — pool size silently wrong |
| `PostgresConfig.SkipMigrations` | `skipmigrations` | `skipmigrations` | `skipmigrations` | Coincidental match |
| `PostgresConfig.RequireSSL` | `requiressl` | `requiressl` | `requireSSL` | **Never read** — SSL silently disabled |

### Fix

Added `yaml:` tags matching the documented config keys:
- `SqliteConfig.DatabaseFileName`: `yaml:"dbfile"`
- `PostgresConfig.MaxOpenConnections`: `yaml:"maxconnections"`
- `PostgresConfig.RequireSSL`: `yaml:"requireSSL"` (matches `sample-conf.yaml:168`)
- `PostgresConfig.SkipMigrations` and `SqliteConfig.SkipMigrations`: `yaml:"skipmigrations"` (no behaviour change, added for explicitness and rename safety)

## Test plan

- [ ] Configure aperture with `dbfile: /path/to/db` in YAML; confirm SQLite opens correctly.
- [ ] Configure with `maxconnections: 5`; confirm pool size is respected.
- [ ] Configure with `requireSSL: true`; confirm TLS connection is required.