### PR TITLE
Add L402 discovery: manifest + quote endpoints

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lightninglabs/aperture/aperturedb"
 	"github.com/lightninglabs/aperture/auth"
 	"github.com/lightninglabs/aperture/challenger"
+	"github.com/lightninglabs/aperture/discovery"
 	"github.com/lightninglabs/aperture/lnc"
 	"github.com/lightninglabs/aperture/mint"
 	"github.com/lightninglabs/aperture/proxy"
@@ -1751,11 +1752,38 @@ func createProxy(cfg *Config, services []*proxy.Service,
 		},
 	))
 
+	// Wire the L402 discovery endpoints (the free manifest and the quote
+	// endpoint) as priority local services so they bypass the 402 gate, the
+	// same way the admin and dashboard endpoints do. They are always on, and
+	// reuse the same minter as the reactive flow so quote credentials are
+	// indistinguishable at verification time.
+	discoveryServer := discovery.New(discovery.Config{
+		Services: func() []*proxy.Service { return services },
+		Minter:   minter,
+		Provider: discovery.Provider{Name: providerName(cfg)},
+	})
+	priorityServices := append(
+		[]proxy.LocalService{
+			discoveryServer.ManifestService(),
+			discoveryServer.QuoteService(),
+		},
+		adminPriorityServices...,
+	)
+
 	prxy, err := proxy.New(
 		authenticator, services, cfg.Blocklist,
-		adminPriorityServices, localServices...,
+		priorityServices, localServices...,
 	)
 	return prxy, proxyCleanup, err
+}
+
+// providerName derives a human-readable provider name for the discovery
+// manifest from the configuration.
+func providerName(cfg *Config) string {
+	if cfg.Authenticator != nil && cfg.Authenticator.MPPRealm != "" {
+		return cfg.Authenticator.MPPRealm
+	}
+	return cfg.ListenAddr
 }
 
 // createHashMailServer creates the gRPC server for the hash mail message

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,0 +1,386 @@
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/aperture/l402"
+	"github.com/lightninglabs/aperture/pricer"
+	"github.com/lightninglabs/aperture/proxy"
+	"gopkg.in/macaroon.v2"
+)
+
+// fakeMinter records the parameters of the last mint and returns a real
+// macaroon carrying the supplied caveats.
+type fakeMinter struct {
+	price       int64
+	serviceName string
+	caveats     []l402.Caveat
+	err         error
+}
+
+func (f *fakeMinter) MintL402WithCaveats(_ context.Context, price int64,
+	serviceName string, caveats ...l402.Caveat) (*macaroon.Macaroon, string,
+	error) {
+
+	if f.err != nil {
+		return nil, "", f.err
+	}
+
+	f.price = price
+	f.serviceName = serviceName
+	f.caveats = caveats
+
+	var buf bytes.Buffer
+	if err := l402.EncodeIdentifier(&buf, &l402.Identifier{
+		Version: l402.LatestVersion,
+	}); err != nil {
+		return nil, "", err
+	}
+
+	var rootKey [l402.SecretSize]byte
+	mac, err := macaroon.New(
+		rootKey[:], buf.Bytes(), "lsat", macaroon.LatestVersion,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := l402.AddFirstPartyCaveats(mac, caveats...); err != nil {
+		return nil, "", err
+	}
+
+	return mac, "lnbc100n1pexample", nil
+}
+
+func fixedTime() time.Time {
+	return time.Unix(1_700_000_000, 0)
+}
+
+func newServer(minter Minter, services ...*proxy.Service) *Server {
+	return New(Config{
+		Services: func() []*proxy.Service { return services },
+		Minter:   minter,
+		Provider: Provider{Name: "test"},
+		Now:      fixedTime,
+	})
+}
+
+func weatherService() *proxy.Service {
+	return &proxy.Service{
+		Name:         "weather",
+		PathRegexp:   "/v1/forecast",
+		Capabilities: "forecast,historical",
+		Price:        21,
+		Constraints: map[string]string{
+			"weather_monthly_requests": "1000000",
+		},
+		Timeout: 3600,
+	}
+}
+
+func formulaService() *proxy.Service {
+	return &proxy.Service{
+		Name:         "weather",
+		PathRegexp:   "/v1/forecast",
+		Capabilities: "forecast",
+		Formula: pricer.FormulaConfig{
+			Enabled:  true,
+			BaseMsat: 1000,
+			Components: []*pricer.FormulaComponent{
+				{
+					Constraint:       "forecast_monthly_requests",
+					PriceMsatPerUnit: 10,
+					Unit:             1,
+				},
+			},
+		},
+		Constraints: map[string]string{
+			"forecast_monthly_requests": "1000000",
+		},
+	}
+}
+
+func TestManifestHandler(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&fakeMinter{}, weatherService())
+
+	req := httptest.NewRequest(http.MethodGet, ManifestPath, nil)
+	rec := httptest.NewRecorder()
+	srv.ManifestService().(http.Handler).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type = %q", ct)
+	}
+	if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Fatalf("missing permissive CORS header")
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if m.Version != ManifestVersion {
+		t.Fatalf("version = %q", m.Version)
+	}
+	if m.QuoteEndpoint != QuotePath {
+		t.Fatalf("quote_endpoint = %q", m.QuoteEndpoint)
+	}
+	if len(m.Services) != 1 || m.Services[0].Name != "weather" {
+		t.Fatalf("unexpected services: %+v", m.Services)
+	}
+	if got := m.Services[0].Resources[0].Pricing; got.Model != pricingFixed ||
+		got.PriceMsat != 21*msatPerSat {
+
+		t.Fatalf("pricing = %+v", got)
+	}
+	if _, ok := m.Caveats["weather_capabilities"]; !ok {
+		t.Fatalf("missing capabilities caveat spec")
+	}
+	if _, ok := m.Caveats["weather_valid_until"]; !ok {
+		t.Fatalf("missing timeout caveat spec")
+	}
+}
+
+func TestManifestFormulaPricing(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&fakeMinter{}, formulaService())
+	m := BuildManifest(srv.cfg.Provider, QuotePath, "", srv.cfg.Services())
+
+	pr := m.Services[0].Resources[0].Pricing
+	if pr.Model != pricingFormula {
+		t.Fatalf("model = %q, want formula", pr.Model)
+	}
+	if pr.BaseMsat != 1000 || len(pr.Components) != 1 {
+		t.Fatalf("formula = %+v", pr)
+	}
+	if pr.Components[0].Constraint != "forecast_monthly_requests" {
+		t.Fatalf("component = %+v", pr.Components[0])
+	}
+}
+
+func postQuote(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(
+		http.MethodPost, QuotePath, strings.NewReader(body),
+	)
+	rec := httptest.NewRecorder()
+	srv.QuoteService().(http.Handler).ServeHTTP(rec, req)
+	return rec
+}
+
+func TestQuoteFixedSuccess(t *testing.T) {
+	t.Parallel()
+
+	minter := &fakeMinter{}
+	srv := newServer(minter, weatherService())
+
+	rec := postQuote(t, srv, `{
+		"service": "weather",
+		"capabilities": ["forecast"],
+		"constraints": {"weather_monthly_requests": 500000}
+	}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp QuoteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.PriceMsat != 21*msatPerSat {
+		t.Fatalf("price_msat = %d", resp.PriceMsat)
+	}
+	if resp.Invoice == "" || resp.Macaroon == "" {
+		t.Fatalf("missing macaroon/invoice")
+	}
+	if resp.QuoteExpiry != fixedTime().Add(defaultQuoteValidity).Unix() {
+		t.Fatalf("quote_expiry = %d", resp.QuoteExpiry)
+	}
+
+	// The minted bundle must carry the services caveat, the narrowed
+	// capability, the chosen constraint value, and the timeout.
+	caveats := caveatMap(minter.caveats)
+	if caveats["services"] != "weather:0" {
+		t.Fatalf("services caveat = %q", caveats["services"])
+	}
+	if caveats["weather_capabilities"] != "forecast" {
+		t.Fatalf("capabilities caveat = %q",
+			caveats["weather_capabilities"])
+	}
+	if caveats["weather_monthly_requests"] != "500000" {
+		t.Fatalf("constraint caveat = %q",
+			caveats["weather_monthly_requests"])
+	}
+	if _, ok := caveats["weather_valid_until"]; !ok {
+		t.Fatalf("missing timeout caveat")
+	}
+}
+
+func TestQuoteFormulaPrice(t *testing.T) {
+	t.Parallel()
+
+	minter := &fakeMinter{}
+	srv := newServer(minter, formulaService())
+
+	rec := postQuote(t, srv, `{
+		"service": "weather",
+		"constraints": {"forecast_monthly_requests": 100000}
+	}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp QuoteResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	// base 1000 + 10 * 100000 = 1_001_000 msat -> 1001 sats -> 1_001_000 msat.
+	wantMsat := int64(1_001_000)
+	if resp.PriceMsat != wantMsat {
+		t.Fatalf("price_msat = %d, want %d", resp.PriceMsat, wantMsat)
+	}
+	if minter.price != 1001 {
+		t.Fatalf("minted price (sats) = %d, want 1001", minter.price)
+	}
+}
+
+func TestQuoteErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&fakeMinter{}, weatherService())
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "unknown service",
+			body:       `{"service": "nope"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "unknown_service",
+		},
+		{
+			name:       "unknown capability",
+			body:       `{"service": "weather", "capabilities": ["nope"]}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "unknown_capability",
+		},
+		{
+			name: "constraint out of bounds",
+			body: `{"service": "weather",
+				"constraints": {"weather_monthly_requests": 2000000}}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "constraint_out_of_bounds",
+		},
+		{
+			name: "invalid constraint",
+			body: `{"service": "weather",
+				"constraints": {"unknown_thing": 5}}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "invalid_constraint",
+		},
+		{
+			name:       "unsatisfiable budget",
+			body:       `{"service": "weather", "max_price_msat": 1}`,
+			wantStatus: http.StatusConflict,
+			wantCode:   "unsatisfiable_budget",
+		},
+		{
+			name:       "unsupported payment method",
+			body:       `{"service": "weather", "payment_method": "bolt12"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "unsupported_payment_method",
+		},
+		{
+			name:       "unknown tier",
+			body:       `{"service": "weather", "tier": 5}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "unknown_tier",
+		},
+		{
+			name:       "malformed",
+			body:       `{not json`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "malformed_request",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := postQuote(t, srv, tc.body)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %s)",
+					rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			var eb errorBody
+			if err := json.Unmarshal(rec.Body.Bytes(), &eb); err != nil {
+				t.Fatalf("decode error body: %v", err)
+			}
+			if eb.Error.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", eb.Error.Code,
+					tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestQuoteMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&fakeMinter{}, weatherService())
+	req := httptest.NewRequest(http.MethodGet, QuotePath, nil)
+	rec := httptest.NewRecorder()
+	srv.QuoteService().(http.Handler).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestQuoteDisabledWithoutMinter(t *testing.T) {
+	t.Parallel()
+
+	srv := New(Config{
+		Services: func() []*proxy.Service {
+			return []*proxy.Service{weatherService()}
+		},
+		Provider: Provider{Name: "test"},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, QuotePath, nil)
+	if srv.QuoteService().IsHandling(req) {
+		t.Fatalf("quote endpoint should be disabled without a minter")
+	}
+
+	// The manifest should also omit the quote endpoint.
+	m := BuildManifest(srv.cfg.Provider, "", "", srv.cfg.Services())
+	if m.QuoteEndpoint != "" {
+		t.Fatalf("quote_endpoint should be empty, got %q",
+			m.QuoteEndpoint)
+	}
+}
+
+// caveatMap decodes a list of caveats into a condition->value map (last wins).
+func caveatMap(caveats []l402.Caveat) map[string]string {
+	out := make(map[string]string, len(caveats))
+	for _, c := range caveats {
+		out[c.Condition] = c.Value
+	}
+	return out
+}

--- a/discovery/manifest.go
+++ b/discovery/manifest.go
@@ -1,0 +1,237 @@
+// Package discovery implements the server side of the L402 discovery layer: a
+// free static manifest served at /.well-known/l402.json that advertises a
+// provider's services, prices, and caveat vocabulary, and an optional quote
+// endpoint at /l402/quote that turns a client-chosen bundle into a ready-to-pay
+// L402 challenge. See the L402 discovery specification for the wire format.
+package discovery
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/lightninglabs/aperture/proxy"
+)
+
+const (
+	// ManifestPath is the well-known path the discovery manifest is served
+	// at, per RFC 8615.
+	ManifestPath = "/.well-known/l402.json"
+
+	// QuotePath is the default path the quote endpoint is served at.
+	QuotePath = "/l402/quote"
+
+	// ManifestVersion is the schema version this implementation emits.
+	ManifestVersion = "1.0"
+
+	// pricingFixed, pricingFormula, and pricingDynamic are the pricing
+	// models a resource can advertise.
+	pricingFixed   = "fixed"
+	pricingFormula = "formula"
+	pricingDynamic = "dynamic"
+
+	// msatPerSat is the number of millisatoshis in a satoshi. Aperture
+	// prices internally in satoshis; the manifest and quotes are denominated
+	// in millisatoshis per the discovery spec.
+	msatPerSat = 1000
+)
+
+// Provider identifies the entity serving the manifest.
+type Provider struct {
+	Name       string `json:"name"`
+	URI        string `json:"uri,omitempty"`
+	NodePubKey string `json:"node_pubkey,omitempty"`
+}
+
+// Manifest is the top-level discovery document.
+type Manifest struct {
+	Version        string                `json:"version"`
+	Provider       Provider              `json:"provider"`
+	Currencies     []string              `json:"currencies"`
+	MacaroonVers   []int                 `json:"macaroon_versions,omitempty"`
+	PaymentMethods []string              `json:"payment_methods,omitempty"`
+	QuoteEndpoint  string                `json:"quote_endpoint,omitempty"`
+	OpenAPI        string                `json:"openapi,omitempty"`
+	Services       []ServiceEntry        `json:"services"`
+	Caveats        map[string]CaveatSpec `json:"caveats,omitempty"`
+}
+
+// ServiceEntry describes one L402-enabled service.
+type ServiceEntry struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	Tiers        []Tier          `json:"tiers,omitempty"`
+	Capabilities []string        `json:"capabilities,omitempty"`
+	Resources    []ResourceEntry `json:"resources"`
+}
+
+// Tier is one tier of a service. Aperture currently only mints the base tier.
+type Tier struct {
+	Tier int    `json:"tier"`
+	Name string `json:"name,omitempty"`
+}
+
+// ResourceEntry binds an HTTP entry point to a price and constraint bounds.
+type ResourceEntry struct {
+	Path        string                `json:"path,omitempty"`
+	Method      string                `json:"method,omitempty"`
+	Capability  string                `json:"capability,omitempty"`
+	Pricing     Pricing               `json:"pricing"`
+	Constraints map[string]Constraint `json:"constraints,omitempty"`
+}
+
+// Pricing describes how a resource is priced.
+type Pricing struct {
+	Model      string             `json:"model"`
+	PriceMsat  int64              `json:"price_msat,omitempty"`
+	BaseMsat   int64              `json:"base_msat,omitempty"`
+	Components []FormulaComponent `json:"components,omitempty"`
+}
+
+// FormulaComponent is one per-unit charge in a formula price.
+type FormulaComponent struct {
+	Constraint       string `json:"constraint"`
+	PriceMsatPerUnit int64  `json:"price_msat_per_unit"`
+	Unit             int64  `json:"unit,omitempty"`
+}
+
+// Constraint describes the permissible bounds of a constraint a client may set.
+type Constraint struct {
+	Type   string   `json:"type"`
+	Max    *int64   `json:"max,omitempty"`
+	Min    *int64   `json:"min,omitempty"`
+	Values []string `json:"values,omitempty"`
+}
+
+// CaveatSpec describes a caveat condition the provider enforces.
+type CaveatSpec struct {
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	Attenuation string `json:"attenuation,omitempty"`
+}
+
+// BuildManifest constructs the discovery manifest from the configured services.
+func BuildManifest(provider Provider, quoteEndpoint, openAPI string,
+	services []*proxy.Service) *Manifest {
+
+	m := &Manifest{
+		Version:        ManifestVersion,
+		Provider:       provider,
+		Currencies:     []string{"msat"},
+		MacaroonVers:   []int{0},
+		PaymentMethods: []string{"bolt11"},
+		QuoteEndpoint:  quoteEndpoint,
+		OpenAPI:        openAPI,
+		Caveats: map[string]CaveatSpec{
+			"services": {Type: "service_list", Attenuation: "subset"},
+		},
+	}
+
+	for _, svc := range services {
+		if svc.Name == "" {
+			continue
+		}
+
+		entry := serviceEntry(svc)
+		m.Services = append(m.Services, entry)
+
+		// Add the caveat vocabulary contributed by this service.
+		m.Caveats[svc.Name+"_capabilities"] = CaveatSpec{
+			Type:        "string",
+			Attenuation: "subset",
+		}
+		for cond, value := range svc.Constraints {
+			m.Caveats[cond] = constraintCaveatSpec(value)
+		}
+		if svc.Timeout > 0 {
+			m.Caveats[svc.Name+"_valid_until"] = CaveatSpec{
+				Type:        "timestamp",
+				Attenuation: "earlier",
+			}
+		}
+	}
+
+	return m
+}
+
+// serviceEntry maps a single proxy.Service to its manifest entry.
+func serviceEntry(svc *proxy.Service) ServiceEntry {
+	entry := ServiceEntry{
+		Name:  svc.Name,
+		Tiers: []Tier{{Tier: 0, Name: "base"}},
+	}
+	if svc.Capabilities != "" {
+		entry.Capabilities = strings.Split(svc.Capabilities, ",")
+	}
+
+	resource := ResourceEntry{
+		Path:        svc.PathRegexp,
+		Pricing:     pricingFor(svc),
+		Constraints: constraintBounds(svc.Constraints),
+	}
+	entry.Resources = []ResourceEntry{resource}
+
+	return entry
+}
+
+// pricingFor determines the manifest pricing model for a service. Formula takes
+// precedence (it is the discovery-specific model), then dynamic, then fixed.
+func pricingFor(svc *proxy.Service) Pricing {
+	switch {
+	case svc.Formula.Enabled:
+		components := make([]FormulaComponent, 0, len(svc.Formula.Components))
+		for _, c := range svc.Formula.Components {
+			components = append(components, FormulaComponent{
+				Constraint:       c.Constraint,
+				PriceMsatPerUnit: c.PriceMsatPerUnit,
+				Unit:             c.Unit,
+			})
+		}
+		return Pricing{
+			Model:      pricingFormula,
+			BaseMsat:   svc.Formula.BaseMsat,
+			Components: components,
+		}
+
+	case svc.DynamicPrice.Enabled:
+		return Pricing{Model: pricingDynamic}
+
+	default:
+		return Pricing{
+			Model:     pricingFixed,
+			PriceMsat: svc.Price * msatPerSat,
+		}
+	}
+}
+
+// constraintBounds maps a service's configured constraints to manifest
+// constraint bounds. Aperture enforces a fixed value per constraint, which we
+// surface as the upper bound a client may request.
+func constraintBounds(constraints map[string]string) map[string]Constraint {
+	if len(constraints) == 0 {
+		return nil
+	}
+
+	bounds := make(map[string]Constraint, len(constraints))
+	for cond, value := range constraints {
+		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
+			max := n
+			bounds[cond] = Constraint{Type: "integer", Max: &max}
+		} else {
+			bounds[cond] = Constraint{
+				Type:   "string",
+				Values: []string{value},
+			}
+		}
+	}
+
+	return bounds
+}
+
+// constraintCaveatSpec infers the caveat vocabulary entry for a constraint from
+// its configured value.
+func constraintCaveatSpec(value string) CaveatSpec {
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return CaveatSpec{Type: "integer", Attenuation: "decreasing"}
+	}
+	return CaveatSpec{Type: "string", Attenuation: "subset"}
+}

--- a/discovery/server.go
+++ b/discovery/server.go
@@ -1,0 +1,540 @@
+package discovery
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lightninglabs/aperture/l402"
+	"github.com/lightninglabs/aperture/proxy"
+	"gopkg.in/macaroon.v2"
+)
+
+// defaultQuoteValidity is how long a quote (and the invoice it carries) is
+// honored by default.
+const defaultQuoteValidity = 60 * time.Second
+
+// Minter mints an L402 committing to a fresh invoice with a caller-supplied set
+// of caveats. It is satisfied by *mint.Mint.
+type Minter interface {
+	MintL402WithCaveats(ctx context.Context, price int64, serviceName string,
+		caveats ...l402.Caveat) (*macaroon.Macaroon, string, error)
+}
+
+// Config holds the dependencies of the discovery server.
+type Config struct {
+	// Services returns the current set of configured services. It is a
+	// function so the manifest reflects live service updates.
+	Services func() []*proxy.Service
+
+	// Minter mints quote challenges. May be nil to disable the quote
+	// endpoint while still serving the manifest.
+	Minter Minter
+
+	// Provider identifies this provider in the manifest.
+	Provider Provider
+
+	// OpenAPI is the optional URI of an OpenAPI document to advertise.
+	OpenAPI string
+
+	// QuoteValidity is how long a quote is honored. Defaults to one minute.
+	QuoteValidity time.Duration
+
+	// Now returns the current time. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// Server serves the discovery manifest and quote endpoint.
+type Server struct {
+	cfg Config
+}
+
+// New creates a new discovery server.
+func New(cfg Config) *Server {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.QuoteValidity <= 0 {
+		cfg.QuoteValidity = defaultQuoteValidity
+	}
+
+	return &Server{cfg: cfg}
+}
+
+// ManifestService returns the manifest endpoint as a priority local service so
+// it bypasses the 402 gate.
+func (s *Server) ManifestService() proxy.LocalService {
+	return proxy.NewLocalService(
+		http.HandlerFunc(s.handleManifest),
+		func(r *http.Request) bool {
+			return r.URL.Path == ManifestPath
+		},
+	)
+}
+
+// QuoteService returns the quote endpoint as a priority local service. It is
+// only handling requests if a minter is configured.
+func (s *Server) QuoteService() proxy.LocalService {
+	return proxy.NewLocalService(
+		http.HandlerFunc(s.handleQuote),
+		func(r *http.Request) bool {
+			return s.cfg.Minter != nil && r.URL.Path == QuotePath
+		},
+	)
+}
+
+// handleManifest serves the static discovery manifest.
+func (s *Server) handleManifest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, newError(
+			http.StatusMethodNotAllowed, "method_not_allowed",
+			"manifest is fetched with GET", "",
+		))
+		return
+	}
+
+	quoteEndpoint := ""
+	if s.cfg.Minter != nil {
+		quoteEndpoint = QuotePath
+	}
+
+	manifest := BuildManifest(
+		s.cfg.Provider, quoteEndpoint, s.cfg.OpenAPI, s.cfg.Services(),
+	)
+	writeJSON(w, http.StatusOK, manifest)
+}
+
+// QuoteRequest is the body of a quote request.
+type QuoteRequest struct {
+	Service       string                 `json:"service"`
+	Tier          *int                   `json:"tier"`
+	Capabilities  []string               `json:"capabilities"`
+	Constraints   map[string]interface{} `json:"constraints"`
+	MaxPriceMsat  int64                  `json:"max_price_msat"`
+	Optimize      string                 `json:"optimize"`
+	TokenID       string                 `json:"token_id"`
+	PaymentMethod string                 `json:"payment_method"`
+}
+
+// QuoteResponse is the body of a successful quote.
+type QuoteResponse struct {
+	PriceMsat    int64         `json:"price_msat"`
+	QuoteExpiry  int64         `json:"quote_expiry"`
+	Macaroon     string        `json:"macaroon"`
+	Invoice      string        `json:"invoice"`
+	Alternatives []interface{} `json:"alternatives,omitempty"`
+}
+
+// handleQuote serves the quote endpoint.
+func (s *Server) handleQuote(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, newError(
+			http.StatusMethodNotAllowed, "method_not_allowed",
+			"quotes are requested with POST", "",
+		))
+		return
+	}
+
+	var req QuoteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, newError(
+			http.StatusBadRequest, "malformed_request",
+			"invalid JSON body", "",
+		))
+		return
+	}
+
+	resp, apiErr := s.processQuote(r.Context(), &req)
+	if apiErr != nil {
+		writeError(w, apiErr)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// processQuote validates a bundle, prices it, mints a challenge, and assembles
+// the quote response.
+func (s *Server) processQuote(ctx context.Context,
+	req *QuoteRequest) (*QuoteResponse, *apiError) {
+
+	// Only BOLT 11 is supported; BOLT 12 binding is unspecified.
+	if req.PaymentMethod != "" && req.PaymentMethod != "bolt11" {
+		return nil, newError(
+			http.StatusBadRequest, "unsupported_payment_method",
+			"only bolt11 is supported", "payment_method",
+		)
+	}
+
+	svc := s.findService(req.Service)
+	if svc == nil {
+		return nil, newError(
+			http.StatusBadRequest, "unknown_service",
+			"unknown service", "service",
+		)
+	}
+
+	// Aperture only mints the base tier today.
+	if req.Tier != nil && *req.Tier != 0 {
+		return nil, newError(
+			http.StatusBadRequest, "unknown_tier",
+			"only the base tier (0) is offered", "tier",
+		)
+	}
+
+	caps, apiErr := resolveCapabilities(svc, req.Capabilities)
+	if apiErr != nil {
+		return nil, apiErr
+	}
+
+	caveatValues, intValues, apiErr := resolveConstraints(svc, req.Constraints)
+	if apiErr != nil {
+		return nil, apiErr
+	}
+
+	priceSats, apiErr := s.priceBundle(ctx, svc, intValues)
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	priceMsat := priceSats * msatPerSat
+
+	if req.MaxPriceMsat > 0 && priceMsat > req.MaxPriceMsat {
+		return nil, newError(
+			http.StatusConflict, "unsatisfiable_budget",
+			"no offer fits max_price_msat", "max_price_msat",
+		)
+	}
+
+	caveats, err := bundleCaveats(svc, caps, caveatValues, s.cfg.Now)
+	if err != nil {
+		return nil, newError(
+			http.StatusInternalServerError, "mint_failed",
+			err.Error(), "",
+		)
+	}
+
+	mac, invoice, err := s.cfg.Minter.MintL402WithCaveats(
+		ctx, priceSats, svc.Name, caveats...,
+	)
+	if err != nil {
+		return nil, newError(
+			http.StatusInternalServerError, "mint_failed",
+			err.Error(), "",
+		)
+	}
+
+	macBytes, err := mac.MarshalBinary()
+	if err != nil {
+		return nil, newError(
+			http.StatusInternalServerError, "mint_failed",
+			err.Error(), "",
+		)
+	}
+
+	expiry := s.cfg.Now().Add(s.cfg.QuoteValidity).Unix()
+
+	return &QuoteResponse{
+		PriceMsat:   priceMsat,
+		QuoteExpiry: expiry,
+		Macaroon:    base64.StdEncoding.EncodeToString(macBytes),
+		Invoice:     invoice,
+	}, nil
+}
+
+// findService returns the configured service with the given name, or nil.
+func (s *Server) findService(name string) *proxy.Service {
+	for _, svc := range s.cfg.Services() {
+		if svc.Name == name {
+			return svc
+		}
+	}
+	return nil
+}
+
+// priceBundle prices a bundle in satoshis. Formula pricing takes precedence,
+// then dynamic, then the static price.
+func (s *Server) priceBundle(ctx context.Context, svc *proxy.Service,
+	intValues map[string]int64) (int64, *apiError) {
+
+	switch {
+	case svc.Formula.Enabled:
+		priceMsat := svc.Formula.PriceMsat(intValues)
+		return ceilDiv(priceMsat, msatPerSat), nil
+
+	case svc.DynamicPrice.Enabled:
+		// Dynamic pricers price a concrete request. The quote has no
+		// backend request, so we synthesize one against the service's
+		// path. If pricing fails, the bundle is temporarily unpriceable.
+		target := svc.PathRegexp
+		if !strings.HasPrefix(target, "/") {
+			target = "/"
+		}
+		pr, err := http.NewRequestWithContext(
+			ctx, http.MethodGet, target, nil,
+		)
+		if err != nil {
+			return 0, newError(
+				http.StatusServiceUnavailable, "unpriceable",
+				"unable to price dynamic service", "",
+			)
+		}
+		price, err := svc.ResourcePrice(ctx, pr)
+		if err != nil {
+			return 0, newError(
+				http.StatusServiceUnavailable, "unpriceable",
+				"unable to price dynamic service", "",
+			)
+		}
+		return price, nil
+
+	default:
+		return svc.Price, nil
+	}
+}
+
+// resolveCapabilities validates the requested capabilities against the service
+// and returns the effective capability set.
+func resolveCapabilities(svc *proxy.Service,
+	requested []string) ([]string, *apiError) {
+
+	configured := splitNonEmpty(svc.Capabilities)
+	if len(requested) == 0 {
+		return configured, nil
+	}
+
+	allowed := make(map[string]struct{}, len(configured))
+	for _, c := range configured {
+		allowed[c] = struct{}{}
+	}
+	for _, c := range requested {
+		if _, ok := allowed[c]; !ok {
+			return nil, newError(
+				http.StatusBadRequest, "unknown_capability",
+				"capability not offered by service", c,
+			)
+		}
+	}
+
+	return requested, nil
+}
+
+// resolveConstraints validates the requested constraints against the service's
+// configured bounds and formula. It returns the caveat values (as strings) and
+// the integer values used for formula pricing.
+func resolveConstraints(svc *proxy.Service,
+	requested map[string]interface{}) (map[string]string, map[string]int64,
+	*apiError) {
+
+	caveatValues := make(map[string]string)
+	intValues := make(map[string]int64)
+
+	// The set of constraint conditions a client may request is the union of
+	// the configured constraints and any formula component constraints.
+	allowed := make(map[string]struct{})
+	for cond := range svc.Constraints {
+		allowed[cond] = struct{}{}
+	}
+	if svc.Formula.Enabled {
+		for _, c := range svc.Formula.Components {
+			allowed[c.Constraint] = struct{}{}
+		}
+	}
+
+	for cond, raw := range requested {
+		if _, ok := allowed[cond]; !ok {
+			return nil, nil, newError(
+				http.StatusBadRequest, "invalid_constraint",
+				"unknown constraint", cond,
+			)
+		}
+
+		value, ok := stringifyValue(raw)
+		if !ok {
+			return nil, nil, newError(
+				http.StatusBadRequest, "invalid_constraint",
+				"unsupported constraint value type", cond,
+			)
+		}
+		caveatValues[cond] = value
+
+		// If the requested value is an integer, record it for formula
+		// pricing and enforce the configured upper bound, if any.
+		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
+			intValues[cond] = n
+
+			if cfg, ok := svc.Constraints[cond]; ok {
+				if max, err := strconv.ParseInt(cfg, 10, 64); err == nil &&
+					n > max {
+
+					return nil, nil, newError(
+						http.StatusBadRequest,
+						"constraint_out_of_bounds",
+						"value exceeds the advertised "+
+							"maximum", cond,
+					)
+				}
+			}
+		}
+	}
+
+	return caveatValues, intValues, nil
+}
+
+// bundleCaveats maps a validated bundle to the macaroon's first-party caveats:
+// the services caveat, a capabilities caveat, one caveat per constraint (the
+// client's value overriding the configured one where provided), and the
+// service timeout.
+func bundleCaveats(svc *proxy.Service, caps []string,
+	caveatValues map[string]string, now func() time.Time) ([]l402.Caveat,
+	error) {
+
+	servicesCaveat, err := l402.NewServicesCaveat(l402.Service{
+		Name: svc.Name,
+		Tier: l402.BaseTier,
+	})
+	if err != nil {
+		return nil, err
+	}
+	caveats := []l402.Caveat{servicesCaveat}
+
+	if len(caps) > 0 {
+		caveats = append(caveats, l402.NewCapabilitiesCaveat(
+			svc.Name, strings.Join(caps, ","),
+		))
+	}
+
+	// Emit configured constraints, letting the client's chosen value
+	// override the configured default where supplied.
+	emitted := make(map[string]struct{})
+	for cond, configured := range svc.Constraints {
+		value := configured
+		if v, ok := caveatValues[cond]; ok {
+			value = v
+		}
+		caveats = append(caveats, l402.NewCaveat(cond, value))
+		emitted[cond] = struct{}{}
+	}
+
+	// Emit any requested constraints not part of the configured set (for
+	// example formula-only constraints), in deterministic order.
+	for _, cond := range sortedKeys(caveatValues) {
+		if _, done := emitted[cond]; done {
+			continue
+		}
+		caveats = append(caveats, l402.NewCaveat(cond, caveatValues[cond]))
+	}
+
+	if svc.Timeout > 0 {
+		caveats = append(caveats, l402.NewTimeoutCaveat(
+			svc.Name, svc.Timeout, now,
+		))
+	}
+
+	return caveats, nil
+}
+
+// apiError is an error to be rendered as the discovery error envelope.
+type apiError struct {
+	status  int
+	code    string
+	message string
+	field   string
+}
+
+func newError(status int, code, message, field string) *apiError {
+	return &apiError{status: status, code: code, message: message, field: field}
+}
+
+type errorBody struct {
+	Error errorDetail `json:"error"`
+}
+
+type errorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Field   string `json:"field,omitempty"`
+}
+
+// writeError writes the discovery error envelope.
+func writeError(w http.ResponseWriter, e *apiError) {
+	writeJSON(w, e.status, errorBody{
+		Error: errorDetail{
+			Code:    e.code,
+			Message: e.message,
+			Field:   e.field,
+		},
+	})
+}
+
+// writeJSON writes a JSON response with discovery's default headers.
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// stringifyValue renders a JSON-decoded constraint value as the string used in
+// a caveat. Integers are rendered without a decimal point.
+func stringifyValue(raw interface{}) (string, bool) {
+	switch v := raw.(type) {
+	case string:
+		return v, true
+
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10), true
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+
+	case json.Number:
+		return v.String(), true
+
+	default:
+		return "", false
+	}
+}
+
+// splitNonEmpty splits a comma-separated list, dropping empty entries.
+func splitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// sortedKeys returns the keys of a string-keyed map in sorted order.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	return keys
+}
+
+// ceilDiv divides a by b rounding up, for non-negative inputs.
+func ceilDiv(a, b int64) int64 {
+	if b <= 0 {
+		return a
+	}
+	return (a + b - 1) / b
+}

--- a/mint/mint.go
+++ b/mint/mint.go
@@ -137,6 +137,54 @@ func (m *Mint) MintL402(ctx context.Context,
 
 	// TODO(wilmer): remove invoice if any of the operations below fail?
 
+	// Include any restrictions that should be immediately applied to the
+	// L402.
+	var caveats []l402.Caveat
+	if len(services) > 0 {
+		caveats, err = m.caveatsForServices(ctx, services...)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	serviceName := ""
+	if len(services) > 0 {
+		serviceName = services[0].Name
+	}
+
+	return m.mintWithChallenge(
+		ctx, price, paymentRequest, paymentHash, serviceName, caveats,
+	)
+}
+
+// MintL402WithCaveats mints a new L402 committing to a fresh invoice for the
+// given price (in satoshis), attaching exactly the provided first-party caveats.
+// Unlike MintL402, the caveats are supplied directly by the caller rather than
+// derived from the configured ServiceLimiter. This lets callers such as the
+// discovery quote endpoint mint a credential for a client-chosen bundle while
+// reusing the same identifier, secret, and challenge machinery, so the result
+// is indistinguishable from a reactive challenge at verification time.
+func (m *Mint) MintL402WithCaveats(ctx context.Context, price int64,
+	serviceName string, caveats ...l402.Caveat) (*macaroon.Macaroon, string,
+	error) {
+
+	paymentRequest, paymentHash, err := m.cfg.Challenger.NewChallenge(price)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return m.mintWithChallenge(
+		ctx, price, paymentRequest, paymentHash, serviceName, caveats,
+	)
+}
+
+// mintWithChallenge mints an L402 around an already-obtained challenge (payment
+// request + payment hash), attaching the given caveats. It is the shared core
+// of MintL402 and MintL402WithCaveats.
+func (m *Mint) mintWithChallenge(ctx context.Context, price int64,
+	paymentRequest string, paymentHash lntypes.Hash, serviceName string,
+	caveats []l402.Caveat) (*macaroon.Macaroon, string, error) {
+
 	// We can then proceed to mint the L402 with a unique identifier that is
 	// mapped to a unique secret.
 	id, err := createUniqueIdentifier(paymentHash)
@@ -157,18 +205,6 @@ func (m *Mint) MintL402(ctx context.Context,
 		return nil, "", err
 	}
 
-	// Include any restrictions that should be immediately applied to the
-	// L402.
-	var caveats []l402.Caveat
-	if len(services) > 0 {
-		var err error
-		caveats, err = m.caveatsForServices(ctx, services...)
-		if err != nil {
-			// Attempt to revoke the secret to save space.
-			_ = m.cfg.Secrets.RevokeSecret(ctx, idHash)
-			return nil, "", err
-		}
-	}
 	if err := l402.AddFirstPartyCaveats(mac, caveats...); err != nil {
 		// Attempt to revoke the secret to save space.
 		_ = m.cfg.Secrets.RevokeSecret(ctx, idHash)
@@ -186,11 +222,6 @@ func (m *Mint) MintL402(ctx context.Context,
 			log.Errorf("Unable to decode minted macaroon identifier "+
 				"for transaction logging: %v", idErr)
 		} else {
-			serviceName := ""
-			if len(services) > 0 {
-				serviceName = services[0].Name
-			}
-
 			// Compute the identifier hash to link the
 			// transaction to the secrets table.
 			macIDHash := sha256.Sum256(mac.Id())

--- a/pricer/formula.go
+++ b/pricer/formula.go
@@ -1,0 +1,58 @@
+package pricer
+
+// FormulaComponent prices one unit of a constraint value. The charge a
+// component contributes is PriceMsatPerUnit * ceil(value / Unit), where value is
+// the client-selected value for the named constraint.
+type FormulaComponent struct {
+	// Constraint is the caveat condition this component prices. It must
+	// match a key in the service's constraint set.
+	Constraint string `long:"constraint" description:"The constraint condition this component prices"`
+
+	// PriceMsatPerUnit is the charge in millisatoshis per unit of the
+	// constraint value.
+	PriceMsatPerUnit int64 `long:"pricemsatperunit" description:"Charge in millisatoshis per unit of the constraint value"`
+
+	// Unit is the size of a single unit. A value of zero is treated as one.
+	Unit int64 `long:"unit" description:"Size of a single unit (defaults to 1)"`
+}
+
+// FormulaConfig describes a formula pricing model: a base price plus a set of
+// per-unit components that scale with the client's chosen constraint values.
+// The full price is computable by a client from the manifest alone, while the
+// invoice the server ultimately issues remains authoritative.
+type FormulaConfig struct {
+	// Enabled indicates the service advertises formula pricing through the
+	// L402 discovery layer.
+	Enabled bool `long:"enabled" description:"Set to true to advertise formula pricing through L402 discovery"`
+
+	// BaseMsat is the base price in millisatoshis before any per-unit
+	// charges are added.
+	BaseMsat int64 `long:"basemsat" description:"Base price in millisatoshis before per-unit charges"`
+
+	// Components are the per-unit charges keyed by constraint.
+	Components []*FormulaComponent `long:"components" description:"Per-unit charges keyed by constraint"`
+}
+
+// PriceMsat computes the formula price in millisatoshis for the given
+// constraint values. A constraint that has no corresponding requested value
+// contributes nothing.
+func (f *FormulaConfig) PriceMsat(values map[string]int64) int64 {
+	price := f.BaseMsat
+	for _, c := range f.Components {
+		value, ok := values[c.Constraint]
+		if !ok || value <= 0 {
+			continue
+		}
+
+		unit := c.Unit
+		if unit <= 0 {
+			unit = 1
+		}
+
+		// units = ceil(value / unit).
+		units := (value + unit - 1) / unit
+		price += c.PriceMsatPerUnit * units
+	}
+
+	return price
+}

--- a/pricer/formula_test.go
+++ b/pricer/formula_test.go
@@ -1,0 +1,76 @@
+package pricer
+
+import "testing"
+
+func TestFormulaPriceMsat(t *testing.T) {
+	t.Parallel()
+
+	f := &FormulaConfig{
+		BaseMsat: 1000,
+		Components: []*FormulaComponent{
+			{
+				Constraint:       "forecast_monthly_requests",
+				PriceMsatPerUnit: 10,
+				Unit:             1,
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		values map[string]int64
+		want   int64
+	}{
+		{
+			name:   "base only when no values",
+			values: nil,
+			want:   1000,
+		},
+		{
+			name:   "base plus per-unit",
+			values: map[string]int64{"forecast_monthly_requests": 100000},
+			want:   1000 + 10*100000,
+		},
+		{
+			name:   "unknown constraint ignored",
+			values: map[string]int64{"other": 5},
+			want:   1000,
+		},
+		{
+			name:   "non-positive value ignored",
+			values: map[string]int64{"forecast_monthly_requests": 0},
+			want:   1000,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := f.PriceMsat(tc.values); got != tc.want {
+				t.Fatalf("PriceMsat = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormulaUnitRounding(t *testing.T) {
+	t.Parallel()
+
+	// Two msat per 1000 units, rounding up partial units.
+	f := &FormulaConfig{
+		Components: []*FormulaComponent{
+			{Constraint: "bytes", PriceMsatPerUnit: 2, Unit: 1000},
+		},
+	}
+
+	// 1500 bytes = ceil(1500/1000) = 2 units = 4 msat.
+	if got := f.PriceMsat(map[string]int64{"bytes": 1500}); got != 4 {
+		t.Fatalf("PriceMsat = %d, want 4", got)
+	}
+
+	// 1000 bytes = exactly 1 unit = 2 msat.
+	if got := f.PriceMsat(map[string]int64{"bytes": 1000}); got != 2 {
+		t.Fatalf("PriceMsat = %d, want 2", got)
+	}
+}

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -109,6 +110,14 @@ type Service struct {
 	// the pricer if a gPRC server is to be used for price data.
 	DynamicPrice pricer.Config `long:"dynamicprice" description:"Configuration for connecting to the gRPC server to use for the pricer backend"`
 
+	// Formula is an optional formula pricing model surfaced through L402
+	// discovery. When Formula.Enabled is set, the discovery manifest
+	// advertises this service with a "formula" pricing model and the quote
+	// endpoint prices a bundle from the client's chosen constraint values. It
+	// does not affect the reactive 402 price, which continues to use Price or
+	// DynamicPrice.
+	Formula pricer.FormulaConfig `long:"formula" description:"Optional formula pricing model surfaced through L402 discovery"`
+
 	// AuthWhitelistPaths is an optional list of regular expressions that
 	// are matched against the path of the URL of a request. If the request
 	// URL matches any of those regular expressions, the call is treated as
@@ -174,6 +183,21 @@ func (s *Service) prepareRewrite() error {
 	s.Rewrite.Prefix = u.Path
 
 	return nil
+}
+
+// ResourcePrice returns the price in satoshis the service's configured pricer
+// assigns to the given request. It exposes the per-service pricer (static or
+// dynamic gRPC) to callers outside the proxy package, such as the L402
+// discovery quote endpoint. If no pricer has been initialized, the static Price
+// is returned.
+func (s *Service) ResourcePrice(ctx context.Context, r *http.Request) (int64,
+	error) {
+
+	if s.pricer == nil {
+		return s.Price, nil
+	}
+
+	return s.pricer.GetPrice(ctx, r)
 }
 
 // ResourceName returns the string to be used to identify which resource a

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -292,6 +292,23 @@ services:
       # set to true then this path must be set.
       tlscertpath: "path-to-pricer-server-tls-cert/tls.cert"
 
+    # Optional formula pricing surfaced through the L402 discovery layer. When
+    # set, the discovery manifest (/.well-known/l402.json) advertises this
+    # service with a "formula" pricing model, and the quote endpoint
+    # (/l402/quote) prices a bundle from the client's chosen constraint values
+    # as basemsat + sum(pricemsatperunit * ceil(value / unit)). This does not
+    # affect the reactive 402 price, which still uses 'price' or 'dynamicprice'.
+    formula:
+      # Whether this service advertises formula pricing through discovery.
+      enabled: true
+      # Base price in millisatoshis before any per-unit charges.
+      basemsat: 1000
+      # Per-unit charges keyed by the constraint they price.
+      components:
+        - constraint: "add_monthly_volume"
+          pricemsatperunit: 10
+          unit: 1
+
   - name: "service2"
     hostregexp: "service2.com:8083"
     pathregexp: '^/.*$'


### PR DESCRIPTION
In this PR, we add the server side of the L402 discovery layer to aperture, as
specified in [lightninglabs/L402#27](https://github.com/lightninglabs/L402/pull/27).
Today aperture is reactive: a client only learns what a service costs by hitting
it and getting a 402 back. Discovery lets a client see the catalog, the prices,
and the caveat vocabulary up front, and gives us a place for dynamic pricing and
the start of in-protocol negotiation.

Two new endpoints are mounted as priority local services, the same mechanism the
admin and dashboard endpoints use, so they bypass the 402 gate and are always
free. `/.well-known/l402.json` serves a static manifest built from the
configured services: their capabilities, tiers, prices, constraint bounds, and
the caveat conditions the proxy enforces. `/l402/quote` takes a client-chosen
bundle (service, capabilities, constraint values, optional budget), prices it,
maps it to the macaroon's first-party caveats, and mints a ready-to-pay
challenge.

## No new verification machinery

The quote endpoint reuses the existing mint and challenger. We factor the core
of `MintL402` into a shared helper and add `MintL402WithCaveats`, which takes an
explicit price and caveat set instead of deriving them from the static
`ServiceLimiter`. A quote response is just an ordinary L402 challenge minted for
a bundle the client chose, so the credential verifies through the unmodified
base path: nothing downstream of the mint changes.

## Formula pricing

We add a formula pricing model (`basemsat + sum(pricemsatperunit * ceil(value /
unit))`) as a value struct on `proxy.Service`, mirroring `DynamicPrice`. It is
surfaced only through discovery: the manifest advertises it, and the quote
endpoint computes the price from the client's chosen constraint values. The
reactive 402 price is untouched and still uses `Price` or `DynamicPrice`. The
sample config documents the new option.

The quote endpoint returns a structured error envelope on failure, sends
permissive CORS headers (the manifest carries no secrets), and the discovery
package ships with unit tests covering the manifest build, the pricing models,
the bundle-to-caveat mapping, and the error cases.

BOLT 12 is intentionally not wired here: a macaroon must commit to the payment
hash, which a BOLT 12 offer does not expose until an invoice is fetched, so that
binding needs its own treatment, as noted in the spec.
