### PR TITLE
l402: harden authorization header parsing

### DIFF
--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -132,6 +132,17 @@ func TestL402Authenticator(t *testing.T) {
 				result: true,
 			},
 			{
+				id: "valid auth header followed by unrelated value",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"Bearer unrelated",
+					},
+				},
+				result: true,
+			},
+			{
 				id: "valid macaroon metadata header",
 				header: &http.Header{
 					l402.HeaderMacaroonMD: []string{

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/lightninglabs/aperture/auth"
@@ -14,8 +15,13 @@ import (
 
 // createDummyMacHex creates a valid macaroon with dummy content for our tests.
 func createDummyMacHex(preimage string) string {
+	return createDummyMacHexWithID(preimage, "AA==")
+}
+
+// createDummyMacHexWithID creates a valid macaroon with the given ID.
+func createDummyMacHexWithID(preimage, id string) string {
 	dummyMac, err := macaroon.New(
-		[]byte("aabbccddeeff00112233445566778899"), []byte("AA=="),
+		[]byte("aabbccddeeff00112233445566778899"), []byte(id),
 		"aperture", macaroon.LatestVersion,
 	)
 	if err != nil {
@@ -33,16 +39,43 @@ func createDummyMacHex(preimage string) string {
 	return hex.EncodeToString(macBytes)
 }
 
+// createDummyMacHexWithoutPreimage creates a valid macaroon without a
+// preimage caveat.
+func createDummyMacHexWithoutPreimage() string {
+	dummyMac, err := macaroon.New(
+		[]byte("aabbccddeeff00112233445566778899"), []byte("AA=="),
+		"aperture", macaroon.LatestVersion,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	macBytes, err := dummyMac.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+
+	return hex.EncodeToString(macBytes)
+}
+
 // TestL402Authenticator tests that the authenticator properly handles auth
 // headers and the tokens contained in them.
 func TestL402Authenticator(t *testing.T) {
 	var (
 		testPreimage = "49349dfea4abed3cd14f6d356afa83de" +
 			"9787b609f088c8df09bacc7b4bd21b39"
-		testMacHex      = createDummyMacHex(testPreimage)
-		testMacBytes, _ = hex.DecodeString(testMacHex)
-		testMacBase64   = base64.StdEncoding.EncodeToString(
+		otherPreimage = "59349dfea4abed3cd14f6d356afa83de" +
+			"9787b609f088c8df09bacc7b4bd21b39"
+		testMacHex       = createDummyMacHex(testPreimage)
+		noPreimageMacHex = createDummyMacHexWithoutPreimage()
+		otherIDMacHex    = createDummyMacHexWithID(testPreimage, "BB==")
+		testMacBytes, _  = hex.DecodeString(testMacHex)
+		testMacBase64    = base64.StdEncoding.EncodeToString(
 			testMacBytes,
+		)
+		otherIDMacBytes, _ = hex.DecodeString(otherIDMacHex)
+		otherIDMacBase64   = base64.StdEncoding.EncodeToString(
+			otherIDMacBytes,
 		)
 		headerTests = []struct {
 			id       string
@@ -100,12 +133,133 @@ func TestL402Authenticator(t *testing.T) {
 				result: false,
 			},
 			{
+				id: "macaroon header without preimage caveat",
+				header: &http.Header{
+					l402.HeaderMacaroon: []string{noPreimageMacHex},
+				},
+				result: false,
+			},
+			{
+				id: "empty auth header with valid fallback macaroon",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{""},
+					l402.HeaderMacaroon:      []string{testMacHex},
+				},
+				result: false,
+			},
+			{
+				id: "empty metadata header with valid macaroon",
+				header: &http.Header{
+					l402.HeaderMacaroonMD: []string{""},
+					l402.HeaderMacaroon:   []string{testMacHex},
+				},
+				result: false,
+			},
+			{
+				id: "multiple macaroon metadata headers",
+				header: &http.Header{
+					l402.HeaderMacaroonMD: []string{
+						testMacHex, testMacHex,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "multiple macaroon headers",
+				header: &http.Header{
+					l402.HeaderMacaroon: []string{
+						testMacHex, testMacHex,
+					},
+				},
+				result: false,
+			},
+			{
 				id: "valid auth header (both LSAT and L402)",
 				header: &http.Header{
 					l402.HeaderAuthorization: []string{
 						"LSAT " + testMacBase64 + ":" +
 							testPreimage,
 						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: true,
+			},
+			{
+				id: "valid auth header (both L402 and LSAT)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: true,
+			},
+			{
+				id: "different macaroons (LSAT then L402)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + otherIDMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "different macaroons (L402 then LSAT)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + otherIDMacBase64 + ":" +
+							testPreimage,
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "different preimages (LSAT then L402)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							otherPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "different preimages (L402 then LSAT)",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							otherPreimage,
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "case insensitive scheme and uppercase preimage",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"lSaT " + testMacBase64 + ":" +
+							strings.ToUpper(testPreimage),
+					},
+				},
+				result: true,
+			},
+			{
+				id: "multiple spaces after scheme",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402   " + testMacBase64 + ":" +
 							testPreimage,
 					},
 				},
@@ -130,6 +284,186 @@ func TestL402Authenticator(t *testing.T) {
 					},
 				},
 				result: true,
+			},
+			{
+				id: "valid auth header followed by unrelated value",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"Bearer unrelated",
+					},
+				},
+				result: false,
+			},
+			{
+				id: "unrelated value followed by valid auth header",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"Bearer unrelated",
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "invalid macaroon followed by valid auth header",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 !!!!:" + testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "valid auth header followed by invalid macaroon",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT !!!!:" + testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "invalid base64 credential",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 A:" + testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "invalid encoded macaroon credential",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 YQ==:" + testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "invalid base64 followed by valid credential",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT A:" + testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "valid credential followed by invalid base64",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT A:" + testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "invalid encoded macaroon followed by valid credential",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT YQ==:" + testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "valid credential followed by invalid encoded macaroon",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT YQ==:" + testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "invalid preimage length",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":ab",
+					},
+				},
+				result: false,
+			},
+			{
+				id: "duplicate L402 auth headers",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "duplicate LSAT auth headers",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "duplicate LSAT after matching L402 and LSAT",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "duplicate L402 after matching LSAT and L402",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+					},
+				},
+				result: false,
+			},
+			{
+				id: "extra auth header value",
+				header: &http.Header{
+					l402.HeaderAuthorization: []string{
+						"LSAT " + testMacBase64 + ":" +
+							testPreimage,
+						"L402 " + testMacBase64 + ":" +
+							testPreimage,
+						"Bearer unrelated",
+					},
+				},
+				result: false,
 			},
 			{
 				id: "valid macaroon metadata header",
@@ -169,6 +503,50 @@ func TestL402Authenticator(t *testing.T) {
 		if result != testCase.result {
 			t.Fatalf("test case %s failed. got %v expected %v",
 				testCase.id, result, testCase.result)
+		}
+	}
+}
+
+// TestL402AuthenticatorRejectsInvalidCredentialOrder verifies that a
+// structurally valid but unauthorized credential cannot bypass validation
+// when placed before a valid credential.
+func TestL402AuthenticatorRejectsInvalidCredentialOrder(t *testing.T) {
+	const (
+		validPreimage = "49349dfea4abed3cd14f6d356afa83de" +
+			"9787b609f088c8df09bacc7b4bd21b39"
+		invalidPreimage = "59349dfea4abed3cd14f6d356afa83de" +
+			"9787b609f088c8df09bacc7b4bd21b39"
+	)
+
+	validMacHex := createDummyMacHex(validPreimage)
+	invalidMacHex := createDummyMacHexWithID(invalidPreimage, "BB==")
+	validMacBytes, _ := hex.DecodeString(validMacHex)
+	invalidMacBytes, _ := hex.DecodeString(invalidMacHex)
+	validMacBase64 := base64.StdEncoding.EncodeToString(validMacBytes)
+	invalidMacBase64 := base64.StdEncoding.EncodeToString(invalidMacBytes)
+
+	headerValues := [][]string{
+		{
+			"LSAT " + invalidMacBase64 + ":" + invalidPreimage,
+			"L402 " + validMacBase64 + ":" + validPreimage,
+		},
+		{
+			"L402 " + validMacBase64 + ":" + validPreimage,
+			"LSAT " + invalidMacBase64 + ":" + invalidPreimage,
+		},
+	}
+
+	for i, values := range headerValues {
+		header := http.Header{
+			l402.HeaderAuthorization: values,
+		}
+		a := auth.NewL402Authenticator(
+			&mockMint{rejectMacaroonHex: invalidMacHex},
+			&mockChecker{},
+		)
+
+		if a.Accept(&header, "test") {
+			t.Errorf("header order %d unexpectedly authenticated", i)
 		}
 	}
 }

--- a/auth/mock_test.go
+++ b/auth/mock_test.go
@@ -2,6 +2,8 @@ package auth_test
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"time"
 
 	"github.com/lightninglabs/aperture/auth"
@@ -13,6 +15,7 @@ import (
 )
 
 type mockMint struct {
+	rejectMacaroonHex string
 }
 
 var _ auth.Minter = (*mockMint)(nil)
@@ -24,6 +27,16 @@ func (m *mockMint) MintL402(_ context.Context,
 }
 
 func (m *mockMint) VerifyL402(_ context.Context, p *mint.VerificationParams) error {
+	if m.rejectMacaroonHex != "" {
+		macBytes, err := p.Macaroon.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		if hex.EncodeToString(macBytes) == m.rejectMacaroonHex {
+			return errors.New("macaroon rejected")
+		}
+	}
+
 	return nil
 }
 

--- a/l402/header.go
+++ b/l402/header.go
@@ -60,6 +60,8 @@ func FromHeader(header *http.Header) (*macaroon.Macaroon, lntypes.Preimage, erro
 			if len(matches) != 4 {
 				continue
 			}
+
+			break
 		}
 
 		if len(matches) != 4 {

--- a/l402/header.go
+++ b/l402/header.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/lightningnetwork/lnd/lntypes"
 	"gopkg.in/macaroon.v2"
@@ -27,7 +28,17 @@ const (
 )
 
 var (
-	authRegex        = regexp.MustCompile("(LSAT|L402) (.*?):([a-f0-9]{64})")
+	// authRegex matches the supported Authorization credential format:
+	//
+	//     (LSAT / L402) 1*SP base64(macaroon) ":" 1*HEXDIG
+	//
+	// The L402 specification also allows multiple comma-separated
+	// macaroons. Aperture currently supports exactly one macaroon per
+	// credential.
+	authRegex = regexp.MustCompile(
+		"^(?i:(LSAT|L402))[ ]+([A-Za-z0-9+/=]+):" +
+			"([0-9a-fA-F]+)$",
+	)
 	authFormatLegacy = "LSAT %s:%s"
 	authFormat       = "L402 %s:%s"
 )
@@ -43,84 +54,111 @@ var (
 // If only the macaroon is sent in header 2 or three then it is expected to have
 // a caveat with the preimage attached to it.
 func FromHeader(header *http.Header) (*macaroon.Macaroon, lntypes.Preimage, error) {
-	var authHeader string
+	var (
+		macBase64   string
+		macBytes    []byte
+		preimageHex string
+		err         error
+	)
+
+	authHeaders := header.Values(HeaderAuthorization)
+	macaroonMDHeaders := header.Values(HeaderMacaroonMD)
+	macaroonHeaders := header.Values(HeaderMacaroon)
 
 	switch {
 	// Header field 1 contains the macaroon and the preimage as distinct
 	// values separated by a colon.
-	case header.Get(HeaderAuthorization) != "":
-		// Parse the content of the header field and check that it is in
-		// the correct format.
-		var matches []string
-		authHeaders := header.Values(HeaderAuthorization)
+	case len(authHeaders) > 0:
+		seenSchemes := make(map[string]struct{}, 2)
 		for _, authHeader := range authHeaders {
 			log.Debugf("Trying to authorize with header value "+
 				"[%s].", authHeader)
-			matches = authRegex.FindStringSubmatch(authHeader)
+			matches := authRegex.FindStringSubmatch(authHeader)
 			if len(matches) != 4 {
+				return nil, lntypes.Preimage{}, fmt.Errorf("invalid "+
+					"auth header format: %s", authHeader)
+			}
+
+			currentScheme := strings.ToUpper(matches[1])
+			currentMacBase64 := matches[2]
+			currentPreimageHex := matches[3]
+			if _, ok := seenSchemes[currentScheme]; ok {
+				return nil, lntypes.Preimage{}, fmt.Errorf(
+					"duplicate %s auth header", currentScheme,
+				)
+			}
+			seenSchemes[currentScheme] = struct{}{}
+
+			if len(seenSchemes) == 1 {
+				macBase64 = currentMacBase64
+				preimageHex = currentPreimageHex
 				continue
+			}
+
+			if currentMacBase64 != macBase64 ||
+				currentPreimageHex != preimageHex {
+				return nil, lntypes.Preimage{}, errors.New(
+					"authorization credentials do not match",
+				)
 			}
 		}
 
-		if len(matches) != 4 {
-			return nil, lntypes.Preimage{}, fmt.Errorf("invalid "+
-				"auth header format: %s", authHeader)
-		}
-
-		// Decode the content of the two parts of the header value.
-		macBase64, preimageHex := matches[2], matches[3]
-		macBytes, err := base64.StdEncoding.DecodeString(macBase64)
-		if err != nil {
-			return nil, lntypes.Preimage{}, fmt.Errorf("base64 "+
-				"decode of macaroon failed: %v", err)
-		}
-		mac := &macaroon.Macaroon{}
-		err = mac.UnmarshalBinary(macBytes)
-		if err != nil {
-			return nil, lntypes.Preimage{}, fmt.Errorf("unable to "+
-				"unmarshal macaroon: %v", err)
-		}
-		preimage, err := lntypes.MakePreimageFromStr(preimageHex)
-		if err != nil {
-			return nil, lntypes.Preimage{}, fmt.Errorf("hex "+
-				"decode of preimage failed: %v", err)
-		}
-
-		// All done, we don't need to extract anything from the
-		// macaroon since the preimage was presented separately.
-		return mac, preimage, nil
-
 	// Header field 2: Contains only the macaroon.
-	case header.Get(HeaderMacaroonMD) != "":
-		authHeader = header.Get(HeaderMacaroonMD)
+	case len(macaroonMDHeaders) > 0:
+		if len(macaroonMDHeaders) != 1 {
+			return nil, lntypes.Preimage{}, errors.New(
+				"multiple macaroon metadata headers",
+			)
+		}
+		macBytes, err = hex.DecodeString(macaroonMDHeaders[0])
+		if err != nil {
+			return nil, lntypes.Preimage{}, fmt.Errorf("hex decode of "+
+				"macaroon failed: %v", err)
+		}
 
 	// Header field 3: Contains only the macaroon.
-	case header.Get(HeaderMacaroon) != "":
-		authHeader = header.Get(HeaderMacaroon)
+	case len(macaroonHeaders) > 0:
+		if len(macaroonHeaders) != 1 {
+			return nil, lntypes.Preimage{}, errors.New(
+				"multiple macaroon headers",
+			)
+		}
+		macBytes, err = hex.DecodeString(macaroonHeaders[0])
+		if err != nil {
+			return nil, lntypes.Preimage{}, fmt.Errorf("hex decode of "+
+				"macaroon failed: %v", err)
+		}
 
 	default:
 		return nil, lntypes.Preimage{}, fmt.Errorf("no auth header " +
 			"provided")
 	}
 
-	// For case 2 and 3, we need to actually unmarshal the macaroon to
-	// extract the preimage.
-	macBytes, err := hex.DecodeString(authHeader)
-	if err != nil {
-		return nil, lntypes.Preimage{}, fmt.Errorf("hex decode of "+
-			"macaroon failed: %v", err)
+	if macBytes == nil {
+		macBytes, err = base64.StdEncoding.DecodeString(macBase64)
+		if err != nil {
+			return nil, lntypes.Preimage{}, fmt.Errorf("base64 "+
+				"decode of macaroon failed: %v", err)
+		}
 	}
+
 	mac := &macaroon.Macaroon{}
 	err = mac.UnmarshalBinary(macBytes)
 	if err != nil {
 		return nil, lntypes.Preimage{}, fmt.Errorf("unable to "+
 			"unmarshal macaroon: %v", err)
 	}
-	preimageHex, ok := HasCaveat(mac, PreimageKey)
-	if !ok {
-		return nil, lntypes.Preimage{}, errors.New("preimage caveat " +
-			"not found")
+
+	if preimageHex == "" {
+		var ok bool
+		preimageHex, ok = HasCaveat(mac, PreimageKey)
+		if !ok {
+			return nil, lntypes.Preimage{}, errors.New(
+				"preimage caveat not found",
+			)
+		}
 	}
+
 	preimage, err := lntypes.MakePreimageFromStr(preimageHex)
 	if err != nil {
 		return nil, lntypes.Preimage{}, fmt.Errorf("hex decode of "+


### PR DESCRIPTION
## Summary

- Harden parsing of L402 authorization headers.
- Reject empty, duplicate, malformed, or extra authentication headers.
- Accept one LSAT, one L402, or matching LSAT and L402 credentials in either order.
- Deduplicate macaroon and preimage decoding across supported header formats.

## Details

`SetHeader` emits both LSAT and L402 credentials for compatibility with older Aperture versions. When both are present, `FromHeader` requires their encoded macaroon and encoded preimage values to be identical.

Aperture currently supports exactly one macaroon per credential. The comma-separated multiple-macaroon form allowed by the L402 specification is not supported.

An Authorization header is considered present even when its value is empty.

This prevents an empty Authorization value from bypassing validation and falling back to another macaroon header.

## Testing

- `go test ./auth ./l402 -count=1`
- `go test ./...`