### PR TITLE
l402: pay challenge invoices via router's SendPaymentV2

### DIFF
--- a/l402/client_interceptor.go
+++ b/l402/client_interceptor.go
@@ -388,31 +388,55 @@ func (i *ClientInterceptor) payL402Token(ctx context.Context, md *metadata.MD) (
 	}
 
 	// Pay invoice now and wait for the result to arrive or the main context
-	// being canceled.
+	// being canceled. The payment is dispatched through lnd's router
+	// subserver (SendPaymentV2), as the legacy SendPaymentSync RPC that
+	// was used previously is deprecated and payments made through it can
+	// fail to initiate on recent lnd versions.
 	payCtx, cancel := context.WithTimeout(ctx, PaymentTimeout)
 	defer cancel()
-	respChan := i.lnd.Client.PayInvoice(
-		payCtx, invoiceStr, i.maxFee, nil,
+	payStatusChan, payErrChan, err := i.lnd.Router.SendPayment(
+		payCtx, lndclient.SendPaymentRequest{
+			Invoice: invoiceStr,
+			MaxFee:  i.maxFee,
+			Timeout: PaymentTimeout,
+		},
 	)
-	select {
-	case result := <-respChan:
-		if result.Err != nil {
-			return nil, result.Err
+	if err != nil {
+		return nil, fmt.Errorf("unable to dispatch payment: %v", err)
+	}
+
+	for {
+		select {
+		case result := <-payStatusChan:
+			switch result.State {
+			// The payment was successful, we have all the
+			// information we need and can return the fully paid
+			// token.
+			case lnrpc.Payment_SUCCEEDED:
+				token.Preimage = result.Preimage
+				token.AmountPaid = result.Value
+				token.RoutingFeePaid = result.Fee
+				return token, i.store.StoreToken(token)
+
+			case lnrpc.Payment_FAILED:
+				return nil, fmt.Errorf("payment failed: %v",
+					result.FailureReason)
+
+			// Any other state means the payment is still in
+			// flight, we keep waiting for a terminal update.
+			}
+
+		case err := <-payErrChan:
+			return nil, fmt.Errorf("error paying invoice: %v", err)
+
+		case <-payCtx.Done():
+			return nil, fmt.Errorf("payment timed out. try again "+
+				"to track payment. %s", manualRetryHint)
+
+		case <-ctx.Done():
+			return nil, fmt.Errorf("parent context canceled. try "+
+				"again to track payment. %s", manualRetryHint)
 		}
-		token.Preimage = result.Preimage
-		token.AmountPaid = lnwire.NewMSatFromSatoshis(result.PaidAmt)
-		token.RoutingFeePaid = lnwire.NewMSatFromSatoshis(
-			result.PaidFee,
-		)
-		return token, i.store.StoreToken(token)
-
-	case <-payCtx.Done():
-		return nil, fmt.Errorf("payment timed out. try again to track "+
-			"payment. %s", manualRetryHint)
-
-	case <-ctx.Done():
-		return nil, fmt.Errorf("parent context canceled. try again to"+
-			"track payment. %s", manualRetryHint)
 	}
 }
 

--- a/l402/client_interceptor_test.go
+++ b/l402/client_interceptor_test.go
@@ -26,7 +26,7 @@ type interceptTestCase struct {
 	resetCb             func(addL402 bool)
 	expectLndCall       bool
 	expectSecondLndCall bool
-	sendPaymentCb       func(*testing.T, test.PaymentChannelMessage)
+	sendPaymentCb       func(*testing.T, test.RouterPaymentChannelMessage)
 	trackPaymentCb      func(*testing.T, test.TrackPaymentMessage)
 	expectToken         bool
 	expectInterceptErr  string
@@ -103,17 +103,18 @@ var (
 		},
 		expectLndCall: true,
 		sendPaymentCb: func(t *testing.T,
-			msg test.PaymentChannelMessage) {
+			msg test.RouterPaymentChannelMessage) {
 
 			require.Len(t, callMD, 0)
 
 			// The next call to the "backend" shouldn't return an
 			// error.
 			resetBackend(nil, []string{})
-			msg.Done <- lndclient.PaymentResult{
+			msg.Updates <- lndclient.PaymentStatus{
+				State:    lnrpc.Payment_SUCCEEDED,
 				Preimage: paidPreimage,
-				PaidAmt:  123,
-				PaidFee:  345,
+				Value:    123_000,
+				Fee:      345_000,
 			}
 		},
 		trackPaymentCb: func(t *testing.T,
@@ -149,7 +150,7 @@ var (
 		},
 		expectLndCall: true,
 		sendPaymentCb: func(t *testing.T,
-			msg test.PaymentChannelMessage) {
+			msg test.RouterPaymentChannelMessage) {
 
 			t.Fatal("didn't expect call to sendPayment")
 		},
@@ -181,17 +182,18 @@ var (
 		expectLndCall:       true,
 		expectSecondLndCall: true,
 		sendPaymentCb: func(t *testing.T,
-			msg test.PaymentChannelMessage) {
+			msg test.RouterPaymentChannelMessage) {
 
 			require.Len(t, callMD, 0)
 
 			// The next call to the "backend" shouldn't return an
 			// error.
 			resetBackend(nil, []string{})
-			msg.Done <- lndclient.PaymentResult{
+			msg.Updates <- lndclient.PaymentStatus{
+				State:    lnrpc.Payment_SUCCEEDED,
 				Preimage: paidPreimage,
-				PaidAmt:  123,
-				PaidFee:  345,
+				Value:    123_000,
+				Fee:      345_000,
 			}
 		},
 		trackPaymentCb: func(t *testing.T,
@@ -361,7 +363,7 @@ func testInterceptor(t *testing.T, tc interceptTestCase, addL402 bool,
 	// Simulate payment related calls to lnd, if there are any expected.
 	if tc.expectLndCall {
 		select {
-		case payment := <-lnd.SendPaymentChannel:
+		case payment := <-lnd.RouterSendPaymentChannel:
 			tc.sendPaymentCb(t, payment)
 
 		case track := <-lnd.TrackPaymentChannel:
@@ -373,7 +375,7 @@ func testInterceptor(t *testing.T, tc interceptTestCase, addL402 bool,
 	}
 	if tc.expectSecondLndCall {
 		select {
-		case payment := <-lnd.SendPaymentChannel:
+		case payment := <-lnd.RouterSendPaymentChannel:
 			tc.sendPaymentCb(t, payment)
 
 		case track := <-lnd.TrackPaymentChannel:


### PR DESCRIPTION
## Problem

The L402 client interceptor pays challenge invoices through `lndclient`'s `LightningClient.PayInvoice`, which drives lnd's **legacy `SendPaymentSync` RPC**. That RPC is deprecated in lnd, and on recent builds the payment can fail to even initiate. When that happens the failure mode is nasty:

1. `payL402Token` stores the pending token, dispatches the payment, and times out — the operator sees `payment timed out. try again to track payment`.
2. Every retry then finds the pending token and calls `trackPayment`, which fails with `payment isn't initiated` (lnd has no record of the payment), forever — until the operator manually deletes the pending token file.

**Real-world reproduction:** running `poold` 0.7.1 (which vendors this package) against lnd `0.21.0-beta` on testnet, `InitAccount` consistently failed exactly this way; `lncli listpayments --include_incomplete` showed **zero** payment attempts, confirming the send never reached the router. Paying the same L402 invoice out-of-band via `SendPaymentV2` (`lncli payinvoice`) succeeded in ~1s and, with a hand-completed token, all subsequent auctioneer RPCs worked.

## Change

Dispatch the payment through the **router subserver** (`RouterClient.SendPayment` → `SendPaymentV2`) and consume status updates until a terminal state, mirroring the flow the interceptor's own `trackPayment` already uses. Notes:

- `i.lnd.Router` is already part of the `LndServices` the interceptor holds — no new dependencies.
- `PaymentStatus.Value`/`.Fee` are msat, so the sat→msat conversions drop out.
- Non-terminal states (`IN_FLIGHT` etc.) are consumed and waited out; `FAILED` returns the failure reason; channel errors, the payment timeout, and parent-context cancellation keep their existing messages/hints.
- The internal test mock already implements `RouterClient.SendPayment`, so the interceptor tests move from `SendPaymentChannel` to `RouterSendPaymentChannel` and deliver `PaymentStatus` updates instead of a `PaymentResult`.

## Verification

- `go build ./...`, `go vet ./l402/...` clean
- `go test ./l402/...` passes (all interceptor cases incl. pending-token resume and expired-token repay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)