### PR TITLE
challenger: mint L402 invoices from a Wavelength wallet

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -377,8 +377,22 @@ func (a *Aperture) Start(errChan chan error, shutdown <-chan struct{}) error {
 				"minting invoices from %v",
 				authCfg.WavelengthGateway)
 
+			// An unauthenticated gateway is a deliberate
+			// configuration on the wallet's side, and the daemon
+			// refuses it on mainnet, so say plainly which one this
+			// is rather than leaving the operator to discover it
+			// as a 500 on the first request for a paid resource.
+			if authCfg.WavelengthMacaroonPath == "" {
+				log.Warnf("No wavelengthmacaroonpath set, so " +
+					"invoice requests will carry no " +
+					"credential: this only works against " +
+					"a wallet daemon started with " +
+					"rpc.no-macaroons")
+			}
+
 			client, err := challenger.NewWavelengthInvoiceClient(
 				authCfg.WavelengthGateway, a.cfg.StrictVerify,
+				authCfg.WavelengthMacaroonPath,
 			)
 			if err != nil {
 				return fmt.Errorf("unable to create "+

--- a/aperture.go
+++ b/aperture.go
@@ -372,6 +372,28 @@ func (a *Aperture) Start(errChan chan error, shutdown <-chan struct{}) error {
 					"challenger: %w", err)
 			}
 
+		case authCfg.WavelengthGateway != "":
+			log.Infof("Using wavelength's authenticator config, "+
+				"minting invoices from %v",
+				authCfg.WavelengthGateway)
+
+			client, err := challenger.NewWavelengthInvoiceClient(
+				authCfg.WavelengthGateway, a.cfg.StrictVerify,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to create "+
+					"wavelength invoice client: %w", err)
+			}
+
+			a.challenger, err = challenger.NewLndChallenger(
+				client, a.cfg.InvoiceBatchSize, genInvoiceReq,
+				context.Background, errChan, a.cfg.StrictVerify,
+				challengerOpts...,
+			)
+			if err != nil {
+				return err
+			}
+
 		case authCfg.LndHost != "":
 			log.Infof("Using lnd's authenticator config")
 

--- a/auth/mpp_session_authenticator_test.go
+++ b/auth/mpp_session_authenticator_test.go
@@ -154,7 +154,7 @@ func (m *mockSessionStore) SettleSessionBalance(_ context.Context,
 	if !ok {
 		return 0, fmt.Errorf("session not found")
 	}
-	if s.Status != "open" {
+	if s.Status != sessionStatusOpen {
 		return 0, fmt.Errorf("session already closed")
 	}
 
@@ -182,7 +182,7 @@ func (m *mockSessionStore) CloseSession(_ context.Context,
 	if !ok {
 		return fmt.Errorf("session not found")
 	}
-	if s.Status != "open" {
+	if s.Status != sessionStatusOpen {
 		return fmt.Errorf("session already closed")
 	}
 	s.Status = "closed"
@@ -200,7 +200,7 @@ func (m *mockSessionStore) CloseSessionAndGetBalance(_ context.Context,
 	if !ok {
 		return 0, fmt.Errorf("session not found")
 	}
-	if s.Status != "open" {
+	if s.Status != sessionStatusOpen {
 		return 0, fmt.Errorf("session already closed")
 	}
 	s.Status = "closed"

--- a/auth/mpp_session_pricing_test.go
+++ b/auth/mpp_session_pricing_test.go
@@ -361,9 +361,11 @@ func TestSettleSessionRequestUnknownSession(t *testing.T) {
 // closeSessionForRefund opens a session, spends part of it, and closes it,
 // returning the receipt header the close produced.
 func closeSessionForRefund(t *testing.T, auth *MPPSessionAuthenticator,
-	hmacSecret []byte, deposit, spend int64) http.Header {
+	hmacSecret []byte, spend int64) http.Header {
 
 	t.Helper()
+
+	const deposit = 300
 
 	preimage, paymentHash := testPreimageAndHash(t)
 	auth.checker.(*mockInvoiceChecker).settledHashes[paymentHash] = true
@@ -419,7 +421,7 @@ func receiptRefund(t *testing.T, auth *MPPSessionAuthenticator,
 func TestSessionRefundStatusSkipped(t *testing.T) {
 	auth, _, sender, hmacSecret := newTestSessionAuth(t)
 
-	closeCred := closeSessionForRefund(t, auth, hmacSecret, 300, 300)
+	closeCred := closeSessionForRefund(t, auth, hmacSecret, 300)
 
 	refund, status := receiptRefund(t, auth, closeCred)
 	require.EqualValues(t, 0, refund)
@@ -436,7 +438,7 @@ func TestSessionRefundStatusSkipped(t *testing.T) {
 func TestSessionRefundStatusSucceeded(t *testing.T) {
 	auth, _, sender, hmacSecret := newTestSessionAuth(t)
 
-	closeCred := closeSessionForRefund(t, auth, hmacSecret, 300, 100)
+	closeCred := closeSessionForRefund(t, auth, hmacSecret, 100)
 
 	require.Eventually(t, func() bool {
 		_, status := receiptRefund(t, auth, closeCred)
@@ -464,7 +466,7 @@ func TestSessionRefundStatusFailed(t *testing.T) {
 	auth, _, sender, hmacSecret := newTestSessionAuth(t)
 	sender.err = errors.New("wavelength cannot pay an amountless invoice")
 
-	closeCred := closeSessionForRefund(t, auth, hmacSecret, 300, 100)
+	closeCred := closeSessionForRefund(t, auth, hmacSecret, 100)
 
 	require.Eventually(t, func() bool {
 		refund, status := receiptRefund(t, auth, closeCred)
@@ -491,7 +493,7 @@ func TestSessionRefundInFlightIsNotClaimedSuccessful(t *testing.T) {
 		close(release)
 	})
 
-	closeCred := closeSessionForRefund(t, auth, hmacSecret, 300, 100)
+	closeCred := closeSessionForRefund(t, auth, hmacSecret, 100)
 
 	refund, status := receiptRefund(t, auth, closeCred)
 	require.EqualValues(t, 200, refund)

--- a/challenger/interface.go
+++ b/challenger/interface.go
@@ -30,6 +30,32 @@ type InvoiceClient interface {
 		opts ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error)
 }
 
+// InvoiceTracker is an optional capability of an InvoiceClient. A client that
+// mints its invoices somewhere it cannot then enumerate them, such as a wallet
+// daemon reached over an HTTP gateway, implements it and reports false.
+//
+// It is deliberately a separate interface rather than a method on
+// InvoiceClient. The lnd-backed clients are lnrpc types we do not own and
+// cannot add a method to, so the capability has to be optional, and a client
+// that says nothing is taken to track its invoices exactly as before.
+type InvoiceTracker interface {
+	// TracksInvoices reports whether this client can list its invoices and
+	// subscribe to their state changes.
+	TracksInvoices() bool
+}
+
+// tracksInvoices reports whether an invoice client can be asked about invoice
+// state. A client that does not declare the capability is assumed to have it,
+// which is what every lnd-backed client does.
+func tracksInvoices(client InvoiceClient) bool {
+	tracker, ok := client.(InvoiceTracker)
+	if !ok {
+		return true
+	}
+
+	return tracker.TracksInvoices()
+}
+
 // Challenger is an interface that combines the mint.Challenger and the
 // auth.InvoiceChecker interfaces.
 type Challenger interface {

--- a/challenger/lnd.go
+++ b/challenger/lnd.go
@@ -97,6 +97,34 @@ func NewLndChallenger(client InvoiceClient, batchSize int,
 		opt(challenger)
 	}
 
+	// A client that cannot enumerate its own invoices has no invoice state
+	// to track, and both of the paths that would track it reach for
+	// ListInvoices and SubscribeInvoices, which such a client can only
+	// fail. Settle that here, once, rather than leaving every call site to
+	// remember which backend it wired up: the admin dashboard turns on a
+	// settlement callback without knowing or caring what is minting the
+	// invoices, and that combination used to be a startup crash.
+	if !tracksInvoices(client) {
+		// Strict verification is refused rather than downgraded. It
+		// means the challenger honours a token only once it has seen
+		// that token's invoice settle, so quietly skipping the
+		// tracking would leave aperture believing it was verifying
+		// settlement while honouring tokens for invoices nobody paid.
+		if strictVerification {
+			return nil, fmt.Errorf("strict verification needs an " +
+				"invoice client that can list and subscribe " +
+				"to its invoices")
+		}
+
+		if challenger.onSettled != nil {
+			log.Warnf("Invoice client cannot track invoice " +
+				"state, so settlements will not be recorded " +
+				"for this backend")
+
+			challenger.onSettled = nil
+		}
+	}
+
 	// If a settlement callback is set, create an unbounded concurrent
 	// queue for settlement processing.
 	if challenger.onSettled != nil {

--- a/challenger/lnd_test.go
+++ b/challenger/lnd_test.go
@@ -459,3 +459,149 @@ func TestSettlementQueueDrainOnStop(t *testing.T) {
 	require.GreaterOrEqual(t, len(settled), 1)
 	mu.Unlock()
 }
+
+// untrackedInvoiceClient mints invoices but cannot be asked about them
+// afterwards, which is the shape of every gateway-backed client. It counts the
+// calls it should never see so a test can prove they did not happen, rather
+// than only proving that startup did not fail.
+type untrackedInvoiceClient struct {
+	listCalls      int
+	subscribeCalls int
+}
+
+var _ InvoiceClient = (*untrackedInvoiceClient)(nil)
+var _ InvoiceTracker = (*untrackedInvoiceClient)(nil)
+
+func (u *untrackedInvoiceClient) TracksInvoices() bool {
+	return false
+}
+
+func (u *untrackedInvoiceClient) ListInvoices(_ context.Context,
+	_ *lnrpc.ListInvoiceRequest,
+	_ ...grpc.CallOption) (*lnrpc.ListInvoiceResponse, error) {
+
+	u.listCalls++
+
+	return nil, fmt.Errorf("listing invoices is not supported")
+}
+
+func (u *untrackedInvoiceClient) SubscribeInvoices(_ context.Context,
+	_ *lnrpc.InvoiceSubscription, _ ...grpc.CallOption) (
+	lnrpc.Lightning_SubscribeInvoicesClient, error) {
+
+	u.subscribeCalls++
+
+	return nil, fmt.Errorf("subscribing to invoices is not supported")
+}
+
+func (u *untrackedInvoiceClient) AddInvoice(_ context.Context,
+	_ *lnrpc.Invoice, _ ...grpc.CallOption) (*lnrpc.AddInvoiceResponse,
+	error) {
+
+	return &lnrpc.AddInvoiceResponse{
+		RHash:          lntypes.ZeroHash[:],
+		PaymentRequest: "foo",
+	}, nil
+}
+
+// TestUntrackedClientWithSettlementCallback covers the combination that used
+// to take the whole proxy down on startup: an operator turns on the admin
+// dashboard, which asks for a settlement callback without knowing what is
+// minting the invoices, while the authenticator is a backend that cannot
+// enumerate them. The callback has to be dropped, not honoured, because the
+// only way to honour it is to call methods this client can only fail.
+func TestUntrackedClientWithSettlementCallback(t *testing.T) {
+	t.Parallel()
+
+	client := &untrackedInvoiceClient{}
+	genInvoiceReq := func(int64) (*lnrpc.Invoice, error) {
+		return &lnrpc.Invoice{Value: 99}, nil
+	}
+
+	var settled []lntypes.Hash
+	c, err := NewLndChallenger(
+		client, 10, genInvoiceReq, context.Background,
+		make(chan error), false,
+		WithSettlementCallback(func(hash lntypes.Hash) {
+			settled = append(settled, hash)
+		}),
+	)
+	require.NoError(t, err)
+	defer c.Stop()
+
+	// Neither of the invoice tracking calls may have been attempted, and
+	// no settlement queue should be left running to feed a callback that
+	// can never fire.
+	require.Zero(t, client.listCalls)
+	require.Zero(t, client.subscribeCalls)
+	require.Nil(t, c.onSettled)
+	require.Nil(t, c.settlementQueue)
+	require.Empty(t, settled)
+
+	// Minting still works, which is the one thing this backend is for.
+	_, _, err = c.NewChallenge(99)
+	require.NoError(t, err)
+}
+
+// TestUntrackedClientRefusesStrictVerify checks that the tracking capability
+// is not quietly downgraded. Strict verification means a token is honoured
+// only once its invoice has been seen to settle, so skipping the tracking
+// while leaving the flag on would honour tokens for invoices nobody paid.
+func TestUntrackedClientRefusesStrictVerify(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewLndChallenger(
+		&untrackedInvoiceClient{}, 10,
+		func(int64) (*lnrpc.Invoice, error) {
+			return &lnrpc.Invoice{Value: 99}, nil
+		}, context.Background, make(chan error), true,
+	)
+	require.ErrorContains(t, err, "strict verification")
+}
+
+// TestTrackingClientKeepsSettlementCallback is the other side of the same
+// switch: a client that says nothing about the capability is taken to have it,
+// so the ordinary lnd path is untouched by any of this.
+func TestTrackingClientKeepsSettlementCallback(t *testing.T) {
+	t.Parallel()
+
+	hash := lntypes.Hash{7, 7, 7}
+	mockClient := &mockInvoiceClient{
+		invoices: []*lnrpc.Invoice{
+			newInvoice(hash, 42, lnrpc.Invoice_SETTLED),
+		},
+		updateChan: make(chan *lnrpc.Invoice),
+		errChan:    make(chan error, 1),
+		quit:       make(chan struct{}),
+	}
+
+	var (
+		mu      sync.Mutex
+		settled []lntypes.Hash
+	)
+
+	c, err := NewLndChallenger(
+		mockClient, 10, func(int64) (*lnrpc.Invoice, error) {
+			return &lnrpc.Invoice{Value: 99}, nil
+		}, context.Background, make(chan error), false,
+		WithSettlementCallback(func(hash lntypes.Hash) {
+			mu.Lock()
+			settled = append(settled, hash)
+			mu.Unlock()
+		}),
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.onSettled)
+	require.NotNil(t, c.settlementQueue)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return len(settled) == 1 && settled[0] == hash
+	}, time.Second, 10*time.Millisecond)
+
+	mockClient.stop()
+	c.Stop()
+}

--- a/challenger/wavelength.go
+++ b/challenger/wavelength.go
@@ -1,0 +1,225 @@
+package challenger
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+)
+
+const (
+	// recvPath is the wallet daemon's HTTP/JSON route for requesting an
+	// inbound payment.
+	recvPath = "/v1/wallet/recv"
+
+	// defaultRecvTimeout bounds a single invoice request. Minting happens
+	// inline while a client waits on its 402, so this is deliberately
+	// short: a wallet that has gone away should surface as a failed
+	// challenge rather than holding the request open.
+	defaultRecvTimeout = 30 * time.Second
+)
+
+// WavelengthInvoiceClient mints L402 challenge invoices from a Wavelength
+// wallet daemon instead of from an lnd node.
+//
+// The point of it is what the seller no longer has to run. An invoice from
+// waved is backed by an inbound swap, so the swap server supplies the inbound
+// liquidity and settles the payment into the wallet's Ark balance. The seller
+// therefore needs no Lightning node, no channels, and no inbound capacity to
+// get paid, which is the part of standing up an L402 seller that usually costs
+// the most effort.
+//
+// It satisfies InvoiceClient, so it drives the existing LndChallenger rather
+// than duplicating it. Only AddInvoice is reachable: the other two methods
+// exist to track invoice state, which LndChallenger only does under strict
+// verification, and this backend refuses that mode outright (see
+// NewWavelengthInvoiceClient).
+type WavelengthInvoiceClient struct {
+	// recvURL is the fully resolved endpoint invoices are requested from.
+	recvURL string
+
+	client *http.Client
+}
+
+// A compile-time check that we satisfy the interface the challenger needs.
+var _ InvoiceClient = (*WavelengthInvoiceClient)(nil)
+
+// NewWavelengthInvoiceClient creates an invoice client against the wallet
+// daemon's HTTP/JSON gateway, given its base URL (for example
+// http://localhost:10061).
+//
+// strictVerify is rejected rather than ignored. Strict verification means the
+// challenger watches every invoice's state and refuses a token whose invoice
+// it has not seen settle, which it does by listing and subscribing to
+// invoices. This backend can do neither, so accepting the flag would leave
+// aperture believing it was verifying settlement when it was not: the failure
+// would be silent and would only show up as tokens honoured for invoices that
+// were never paid.
+func NewWavelengthInvoiceClient(gateway string,
+	strictVerify bool) (*WavelengthInvoiceClient, error) {
+
+	if strictVerify {
+		return nil, fmt.Errorf("strictverify is not supported with " +
+			"the wavelength authenticator: the wallet daemon " +
+			"exposes no invoice subscription to verify " +
+			"settlement against")
+	}
+
+	if gateway == "" {
+		return nil, fmt.Errorf("wavelength gateway URL is required")
+	}
+
+	parsed, err := url.Parse(gateway)
+	if err != nil {
+		return nil, fmt.Errorf("invalid wavelength gateway URL %q: %w",
+			gateway, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("wavelength gateway URL %q must be "+
+			"http or https", gateway)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("wavelength gateway URL %q has no host",
+			gateway)
+	}
+
+	return &WavelengthInvoiceClient{
+		recvURL: strings.TrimRight(parsed.String(), "/") + recvPath,
+		client:  &http.Client{Timeout: defaultRecvTimeout},
+	}, nil
+}
+
+// recvRequest asks the wallet for an inbound payment of a given size.
+type recvRequest struct {
+	AmountSat int64  `json:"amt_sat"`
+	Memo      string `json:"memo,omitempty"`
+}
+
+// recvResponse is the wallet's reply. The payment hash is nested under the
+// ledger entry that tracks the receive, and is read from there rather than
+// decoded out of the payment request, so the two can never disagree about
+// which hash this challenge commits to.
+type recvResponse struct {
+	Invoice string `json:"invoice"`
+	Entry   struct {
+		Request struct {
+			LightningInvoice struct {
+				PaymentHash string `json:"payment_hash"`
+			} `json:"lightning_invoice"`
+		} `json:"request"`
+	} `json:"entry"`
+}
+
+// gatewayError is the error shape the gateway returns for a failed call.
+type gatewayError struct {
+	Message string `json:"message"`
+}
+
+// AddInvoice mints a challenge invoice, translating lnd's request and response
+// shapes onto the wallet's receive call.
+func (w *WavelengthInvoiceClient) AddInvoice(ctx context.Context,
+	in *lnrpc.Invoice, _ ...grpc.CallOption) (*lnrpc.AddInvoiceResponse,
+	error) {
+
+	// The mint prices challenges in satoshis, but tolerate a millisatoshi
+	// amount rather than silently minting a zero-value invoice, which the
+	// wallet would reject with a far less obvious error.
+	amountSat := in.Value
+	if amountSat == 0 && in.ValueMsat > 0 {
+		amountSat = in.ValueMsat / 1000
+	}
+	if amountSat <= 0 {
+		return nil, fmt.Errorf("invoice amount must be positive, got "+
+			"%d sat", amountSat)
+	}
+
+	body, err := json.Marshal(&recvRequest{
+		AmountSat: amountSat,
+		Memo:      in.Memo,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal recv request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, w.recvURL, bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build recv request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("call wallet recv: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		var gwErr gatewayError
+		_ = json.NewDecoder(resp.Body).Decode(&gwErr)
+
+		return nil, fmt.Errorf("wallet recv failed (%d): %s",
+			resp.StatusCode, gwErr.Message)
+	}
+
+	var parsed recvResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode recv response: %w", err)
+	}
+
+	if parsed.Invoice == "" {
+		return nil, fmt.Errorf("wallet returned an empty invoice")
+	}
+
+	// The hash is what the macaroon commits to and what the client's
+	// preimage is checked against, so a malformed one has to fail the
+	// challenge here. Letting it through would mint a credential that can
+	// never be satisfied.
+	hash, err := hex.DecodeString(
+		parsed.Entry.Request.LightningInvoice.PaymentHash,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decode payment hash: %w", err)
+	}
+	if len(hash) != 32 {
+		return nil, fmt.Errorf("payment hash must be 32 bytes, got %d",
+			len(hash))
+	}
+
+	return &lnrpc.AddInvoiceResponse{
+		RHash:          hash,
+		PaymentRequest: parsed.Invoice,
+	}, nil
+}
+
+// ListInvoices is unreachable on this backend: the challenger only lists
+// invoices to seed its state cache under strict verification, which
+// NewWavelengthInvoiceClient refuses.
+func (w *WavelengthInvoiceClient) ListInvoices(_ context.Context,
+	_ *lnrpc.ListInvoiceRequest, _ ...grpc.CallOption) (
+	*lnrpc.ListInvoiceResponse, error) {
+
+	return nil, fmt.Errorf("listing invoices is not supported by the " +
+		"wavelength authenticator")
+}
+
+// SubscribeInvoices is unreachable on this backend, for the same reason as
+// ListInvoices.
+func (w *WavelengthInvoiceClient) SubscribeInvoices(_ context.Context,
+	_ *lnrpc.InvoiceSubscription, _ ...grpc.CallOption) (
+	lnrpc.Lightning_SubscribeInvoicesClient, error) {
+
+	return nil, fmt.Errorf("subscribing to invoices is not supported by " +
+		"the wavelength authenticator")
+}

--- a/challenger/wavelength.go
+++ b/challenger/wavelength.go
@@ -133,9 +133,16 @@ func (w *WavelengthInvoiceClient) AddInvoice(ctx context.Context,
 	// The mint prices challenges in satoshis, but tolerate a millisatoshi
 	// amount rather than silently minting a zero-value invoice, which the
 	// wallet would reject with a far less obvious error.
+	//
+	// The conversion rounds up. Rounding down would hand the buyer an
+	// invoice cheaper than the price the mint just quoted, and it would do
+	// so worst where the price is smallest: 1500 msat would mint 1 sat,
+	// and any price below a full satoshi would round to nothing and fail
+	// the challenge outright. Overflow on the addition lands negative and
+	// is caught by the check below, so it fails closed.
 	amountSat := in.Value
 	if amountSat == 0 && in.ValueMsat > 0 {
-		amountSat = in.ValueMsat / 1000
+		amountSat = (in.ValueMsat + 999) / 1000
 	}
 	if amountSat <= 0 {
 		return nil, fmt.Errorf("invoice amount must be positive, got "+

--- a/challenger/wavelength.go
+++ b/challenger/wavelength.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc"
+	macaroon "gopkg.in/macaroon.v2"
 )
 
 const (
@@ -25,6 +27,10 @@ const (
 	// short: a wallet that has gone away should surface as a failed
 	// challenge rather than holding the request open.
 	defaultRecvTimeout = 30 * time.Second
+
+	// macaroonHeader is the HTTP field the wallet daemon's gateway
+	// forwards into the gRPC metadata it authenticates against.
+	macaroonHeader = "macaroon"
 )
 
 // WavelengthInvoiceClient mints L402 challenge invoices from a Wavelength
@@ -45,6 +51,11 @@ type WavelengthInvoiceClient struct {
 	// recvURL is the fully resolved endpoint invoices are requested from.
 	recvURL string
 
+	// macaroonHex authorizes the call, hex encoded because that is the
+	// form the daemon's gateway decodes. Empty means no credential is
+	// sent, which only reaches a daemon running with rpc.no-macaroons.
+	macaroonHex string
+
 	client *http.Client
 }
 
@@ -64,8 +75,15 @@ var _ InvoiceTracker = (*WavelengthInvoiceClient)(nil)
 // aperture believing it was verifying settlement when it was not: the failure
 // would be silent and would only show up as tokens honoured for invoices that
 // were never paid.
-func NewWavelengthInvoiceClient(gateway string,
-	strictVerify bool) (*WavelengthInvoiceClient, error) {
+//
+// macaroonPath authorizes the calls. It may be empty, which is only usable
+// against a daemon started with rpc.no-macaroons; the caller is expected to
+// say so, since from here an unauthenticated gateway is indistinguishable from
+// an operator who forgot. The file is read now rather than on each call so a
+// path that does not exist fails at start-up instead of on the first 402 a
+// real client is waiting on.
+func NewWavelengthInvoiceClient(gateway string, strictVerify bool,
+	macaroonPath string) (*WavelengthInvoiceClient, error) {
 
 	if strictVerify {
 		return nil, fmt.Errorf("strictverify is not supported with " +
@@ -92,10 +110,43 @@ func NewWavelengthInvoiceClient(gateway string,
 			gateway)
 	}
 
+	macaroonHex, err := readMacaroonHex(macaroonPath)
+	if err != nil {
+		return nil, err
+	}
+
 	return &WavelengthInvoiceClient{
-		recvURL: strings.TrimRight(parsed.String(), "/") + recvPath,
-		client:  &http.Client{Timeout: defaultRecvTimeout},
+		recvURL:     strings.TrimRight(parsed.String(), "/") + recvPath,
+		macaroonHex: macaroonHex,
+		client:      &http.Client{Timeout: defaultRecvTimeout},
 	}, nil
+}
+
+// readMacaroonHex loads a binary macaroon and returns it hex encoded, which is
+// the form the gateway decodes. An empty path returns an empty string, meaning
+// no credential will be sent.
+//
+// The bytes are parsed rather than only read, because the failure this catches
+// is pointing the option at the wrong file: a TLS certificate or a truncated
+// download hex encodes perfectly well and is rejected only later, by the
+// daemon, as an authentication failure that says nothing about the cause.
+func readMacaroonHex(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	serialized, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read wavelength macaroon: %w", err)
+	}
+
+	var mac macaroon.Macaroon
+	if err := mac.UnmarshalBinary(serialized); err != nil {
+		return "", fmt.Errorf("file at %q is not a macaroon: %w",
+			path, err)
+	}
+
+	return hex.EncodeToString(serialized), nil
 }
 
 // recvRequest asks the wallet for an inbound payment of a given size.
@@ -164,6 +215,14 @@ func (w *WavelengthInvoiceClient) AddInvoice(ctx context.Context,
 		return nil, fmt.Errorf("build recv request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	// The gateway forwards this field into the gRPC metadata the daemon
+	// authenticates against. Without it a daemon running with macaroons,
+	// which is every daemon that has not been told otherwise, answers 401
+	// and the client waiting on the 402 gets a 500 instead.
+	if w.macaroonHex != "" {
+		req.Header.Set(macaroonHeader, w.macaroonHex)
+	}
 
 	resp, err := w.client.Do(req)
 	if err != nil {

--- a/challenger/wavelength.go
+++ b/challenger/wavelength.go
@@ -38,10 +38,9 @@ const (
 // the most effort.
 //
 // It satisfies InvoiceClient, so it drives the existing LndChallenger rather
-// than duplicating it. Only AddInvoice is reachable: the other two methods
-// exist to track invoice state, which LndChallenger only does under strict
-// verification, and this backend refuses that mode outright (see
-// NewWavelengthInvoiceClient).
+// than duplicating it. Only AddInvoice does any work: the other two methods
+// exist to track invoice state, which this backend cannot do, and it says so
+// through InvoiceTracker so the challenger knows not to ask.
 type WavelengthInvoiceClient struct {
 	// recvURL is the fully resolved endpoint invoices are requested from.
 	recvURL string
@@ -49,8 +48,10 @@ type WavelengthInvoiceClient struct {
 	client *http.Client
 }
 
-// A compile-time check that we satisfy the interface the challenger needs.
+// A compile-time check that we satisfy the interface the challenger needs, and
+// that we declare the one capability we lack.
 var _ InvoiceClient = (*WavelengthInvoiceClient)(nil)
+var _ InvoiceTracker = (*WavelengthInvoiceClient)(nil)
 
 // NewWavelengthInvoiceClient creates an invoice client against the wallet
 // daemon's HTTP/JSON gateway, given its base URL (for example
@@ -203,9 +204,19 @@ func (w *WavelengthInvoiceClient) AddInvoice(ctx context.Context,
 	}, nil
 }
 
-// ListInvoices is unreachable on this backend: the challenger only lists
-// invoices to seed its state cache under strict verification, which
-// NewWavelengthInvoiceClient refuses.
+// TracksInvoices reports that this backend cannot be asked about invoice
+// state. The wallet daemon's gateway exposes minting and nothing else, so
+// there is no way to enumerate the invoices we have handed out or to learn
+// when one of them settles.
+//
+// NOTE: This is part of the InvoiceTracker interface.
+func (w *WavelengthInvoiceClient) TracksInvoices() bool {
+	return false
+}
+
+// ListInvoices is not supported on this backend. The challenger asks for the
+// capability through InvoiceTracker before it calls this, so reaching it means
+// something bypassed that check, and an error is the right answer.
 func (w *WavelengthInvoiceClient) ListInvoices(_ context.Context,
 	_ *lnrpc.ListInvoiceRequest, _ ...grpc.CallOption) (
 	*lnrpc.ListInvoiceResponse, error) {
@@ -214,7 +225,7 @@ func (w *WavelengthInvoiceClient) ListInvoices(_ context.Context,
 		"wavelength authenticator")
 }
 
-// SubscribeInvoices is unreachable on this backend, for the same reason as
+// SubscribeInvoices is not supported on this backend, for the same reason as
 // ListInvoices.
 func (w *WavelengthInvoiceClient) SubscribeInvoices(_ context.Context,
 	_ *lnrpc.InvoiceSubscription, _ ...grpc.CallOption) (

--- a/challenger/wavelength_test.go
+++ b/challenger/wavelength_test.go
@@ -226,3 +226,86 @@ func TestWavelengthGatewayPathJoin(t *testing.T) {
 	require.False(t, strings.Contains(client.recvURL, "//v1"))
 	require.True(t, strings.HasSuffix(client.recvURL, "/v1/wallet/recv"))
 }
+
+// TestWavelengthAddInvoiceRoundsUp checks the millisatoshi conversion never
+// mints an invoice for less than was asked.
+//
+// The mint quotes a price and this client turns it into the whole number of
+// satoshis the wallet is asked to receive. Rounding down would sell the
+// service below the quoted price, and it would misbehave worst where it
+// matters most: a sub-satoshi price would round to nothing and fail the
+// challenge outright, which reads as a broken proxy rather than as a price the
+// wallet cannot express.
+func TestWavelengthAddInvoiceRoundsUp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		valueMsat int64
+		wantSat   int64
+	}{{
+		name:      "exact satoshi is unchanged",
+		valueMsat: 2000,
+		wantSat:   2,
+	}, {
+		name:      "partial satoshi rounds up",
+		valueMsat: 1500,
+		wantSat:   2,
+	}, {
+		name:      "one msat over rounds up",
+		valueMsat: 1001,
+		wantSat:   2,
+	}, {
+		name:      "sub satoshi price still bills a satoshi",
+		valueMsat: 1,
+		wantSat:   1,
+	}, {
+		name:      "just under a satoshi rounds up",
+		valueMsat: 999,
+		wantSat:   1,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, body := newTestWallet(t, func(w http.ResponseWriter,
+				_ *http.Request) {
+
+				_, _ = w.Write([]byte(recvBody(
+					"lnbcrt1", testPaymentHash,
+				)))
+			})
+
+			_, err := client.AddInvoice(
+				context.Background(),
+				&lnrpc.Invoice{ValueMsat: tc.valueMsat},
+			)
+			require.NoError(t, err)
+
+			require.Contains(t, *body, fmt.Sprintf(
+				`"amt_sat":%d`, tc.wantSat,
+			))
+		})
+	}
+}
+
+// TestWavelengthAddInvoicePrefersValue checks that an amount given in satoshis
+// is used as given, rather than being recomputed from the msat field.
+func TestWavelengthAddInvoicePrefersValue(t *testing.T) {
+	t.Parallel()
+
+	client, body := newTestWallet(t, func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		_, _ = w.Write([]byte(recvBody("lnbcrt1", testPaymentHash)))
+	})
+
+	_, err := client.AddInvoice(context.Background(), &lnrpc.Invoice{
+		Value:     7,
+		ValueMsat: 1500,
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, *body, `"amt_sat":7`)
+}

--- a/challenger/wavelength_test.go
+++ b/challenger/wavelength_test.go
@@ -1,0 +1,222 @@
+package challenger
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/stretchr/testify/require"
+)
+
+const testPaymentHash = "161c5af497913d17bcba3edf886d15e4482300b5e4fceaeed0" +
+	"23377a4b2a025e"
+
+// recvBody is the shape the wallet daemon answers a receive request with.
+func recvBody(invoice, hash string) string {
+	return fmt.Sprintf(
+		`{"invoice":%q,"entry":{"request":{"lightning_invoice":`+
+			`{"payment_hash":%q}}}}`, invoice, hash,
+	)
+}
+
+// newTestWallet spins up a stub wallet gateway and returns a client pointed at
+// it, along with a pointer to the last request body it received.
+func newTestWallet(t *testing.T, handler http.HandlerFunc) (
+	*WavelengthInvoiceClient, *string) {
+
+	t.Helper()
+
+	var lastBody string
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			buf := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(buf)
+			lastBody = string(buf)
+
+			handler(w, r)
+		},
+	))
+	t.Cleanup(server.Close)
+
+	client, err := NewWavelengthInvoiceClient(server.URL, false)
+	require.NoError(t, err)
+
+	return client, &lastBody
+}
+
+// TestWavelengthAddInvoice checks the happy path: the amount is passed through
+// in satoshis and both fields the challenger needs come back.
+func TestWavelengthAddInvoice(t *testing.T) {
+	t.Parallel()
+
+	client, body := newTestWallet(t, func(w http.ResponseWriter,
+		r *http.Request) {
+
+		require.Equal(t, "/v1/wallet/recv", r.URL.Path)
+		_, _ = w.Write([]byte(recvBody("lnbcrt115u1p4xjka5", testPaymentHash)))
+	})
+
+	resp, err := client.AddInvoice(context.Background(), &lnrpc.Invoice{
+		Memo:  "L402",
+		Value: 11500,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "lnbcrt115u1p4xjka5", resp.PaymentRequest)
+
+	// The challenger commits this hash to the macaroon and later checks
+	// the client's preimage against it, so it has to survive as raw bytes.
+	expected, err := hex.DecodeString(testPaymentHash)
+	require.NoError(t, err)
+	require.Equal(t, expected, resp.RHash)
+
+	require.Contains(t, *body, `"amt_sat":11500`)
+	require.Contains(t, *body, `"memo":"L402"`)
+}
+
+// TestWavelengthAddInvoiceRejectsBadHash makes sure a hash the client cannot
+// use fails the challenge rather than minting a credential that can never be
+// satisfied: the preimage check would reject every token issued against it.
+func TestWavelengthAddInvoiceRejectsBadHash(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		hash string
+	}{
+		{name: "not hex", hash: "zzzz"},
+		{name: "too short", hash: "0badc0de"},
+		{name: "empty", hash: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newTestWallet(t, func(w http.ResponseWriter,
+				_ *http.Request) {
+
+				_, _ = w.Write([]byte(recvBody("lnbcrt1", tc.hash)))
+			})
+
+			_, err := client.AddInvoice(
+				context.Background(),
+				&lnrpc.Invoice{Value: 11500},
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestWavelengthAddInvoiceSurfacesWalletError checks that the wallet's own
+// explanation reaches the operator instead of a bare status code.
+func TestWavelengthAddInvoiceSurfacesWalletError(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newTestWallet(t, func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"wallet is not ready"}`))
+	})
+
+	_, err := client.AddInvoice(
+		context.Background(), &lnrpc.Invoice{Value: 11500},
+	)
+	require.ErrorContains(t, err, "wallet is not ready")
+}
+
+// TestWavelengthAddInvoiceRejectsNonPositive pins down that a zero-value
+// challenge is refused here rather than at the wallet, where it surfaces as a
+// far less obvious error.
+func TestWavelengthAddInvoiceRejectsNonPositive(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newTestWallet(t, func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		_, _ = w.Write([]byte(recvBody("lnbcrt1", testPaymentHash)))
+	})
+
+	for _, invoice := range []*lnrpc.Invoice{
+		{Value: 0},
+		{Value: -1},
+	} {
+		_, err := client.AddInvoice(context.Background(), invoice)
+		require.ErrorContains(t, err, "must be positive")
+	}
+}
+
+// TestWavelengthAddInvoiceFallsBackToMsat checks the millisatoshi path, so a
+// caller that priced in msat does not silently mint a zero-value invoice.
+func TestWavelengthAddInvoiceFallsBackToMsat(t *testing.T) {
+	t.Parallel()
+
+	client, body := newTestWallet(t, func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		_, _ = w.Write([]byte(recvBody("lnbcrt1", testPaymentHash)))
+	})
+
+	_, err := client.AddInvoice(context.Background(), &lnrpc.Invoice{
+		ValueMsat: 11_500_000,
+	})
+	require.NoError(t, err)
+	require.Contains(t, *body, `"amt_sat":11500`)
+}
+
+// TestWavelengthRejectsStrictVerify is the important guard. Strict
+// verification means refusing tokens whose invoice was never seen to settle,
+// which this backend cannot observe. Accepting the flag would leave aperture
+// believing it verified settlement when it did not.
+func TestWavelengthRejectsStrictVerify(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewWavelengthInvoiceClient("http://localhost:10061", true)
+	require.ErrorContains(t, err, "strictverify is not supported")
+}
+
+// TestWavelengthRejectsBadGateway covers the misconfigurations worth catching
+// at start-up rather than on the first 402 a real client is waiting on.
+func TestWavelengthRejectsBadGateway(t *testing.T) {
+	t.Parallel()
+
+	for _, gateway := range []string{
+		"", "localhost:10061", "ftp://localhost", "http://",
+	} {
+		_, err := NewWavelengthInvoiceClient(gateway, false)
+		require.Error(t, err, "expected %q to be refused", gateway)
+	}
+}
+
+// TestWavelengthTrackingUnsupported documents that the state-tracking half of
+// the interface is unreachable rather than quietly returning empty results,
+// which would read to the challenger as "no invoices exist".
+func TestWavelengthTrackingUnsupported(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewWavelengthInvoiceClient("http://localhost:10061", false)
+	require.NoError(t, err)
+
+	_, err = client.ListInvoices(
+		context.Background(), &lnrpc.ListInvoiceRequest{},
+	)
+	require.Error(t, err)
+
+	_, err = client.SubscribeInvoices(
+		context.Background(), &lnrpc.InvoiceSubscription{},
+	)
+	require.Error(t, err)
+}
+
+// TestWavelengthGatewayPathJoin checks a trailing slash on the configured URL
+// does not produce a double slash in the request path.
+func TestWavelengthGatewayPathJoin(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewWavelengthInvoiceClient("http://localhost:10061/", false)
+	require.NoError(t, err)
+	require.False(t, strings.Contains(client.recvURL, "//v1"))
+	require.True(t, strings.HasSuffix(client.recvURL, "/v1/wallet/recv"))
+}

--- a/challenger/wavelength_test.go
+++ b/challenger/wavelength_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,8 +35,13 @@ func newTestWallet(t *testing.T, handler http.HandlerFunc) (
 	var lastBody string
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			buf := make([]byte, r.ContentLength)
-			_, _ = r.Body.Read(buf)
+			// Read to EOF rather than issuing one Read into a
+			// ContentLength-sized buffer. A single Read may return
+			// a short prefix, which would make the assertions on
+			// this body fail intermittently, and a chunked request
+			// reports a ContentLength of -1, which would panic the
+			// handler goroutine on the make.
+			buf, _ := io.ReadAll(r.Body)
 			lastBody = string(buf)
 
 			handler(w, r)

--- a/challenger/wavelength_test.go
+++ b/challenger/wavelength_test.go
@@ -7,11 +7,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/stretchr/testify/require"
+	macaroon "gopkg.in/macaroon.v2"
 )
 
 const testPaymentHash = "161c5af497913d17bcba3edf886d15e4482300b5e4fceaeed0" +
@@ -49,7 +52,7 @@ func newTestWallet(t *testing.T, handler http.HandlerFunc) (
 	))
 	t.Cleanup(server.Close)
 
-	client, err := NewWavelengthInvoiceClient(server.URL, false)
+	client, err := NewWavelengthInvoiceClient(server.URL, false, "")
 	require.NoError(t, err)
 
 	return client, &lastBody
@@ -179,7 +182,7 @@ func TestWavelengthAddInvoiceFallsBackToMsat(t *testing.T) {
 func TestWavelengthRejectsStrictVerify(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewWavelengthInvoiceClient("http://localhost:10061", true)
+	_, err := NewWavelengthInvoiceClient("http://localhost:10061", true, "")
 	require.ErrorContains(t, err, "strictverify is not supported")
 }
 
@@ -191,7 +194,7 @@ func TestWavelengthRejectsBadGateway(t *testing.T) {
 	for _, gateway := range []string{
 		"", "localhost:10061", "ftp://localhost", "http://",
 	} {
-		_, err := NewWavelengthInvoiceClient(gateway, false)
+		_, err := NewWavelengthInvoiceClient(gateway, false, "")
 		require.Error(t, err, "expected %q to be refused", gateway)
 	}
 }
@@ -202,7 +205,7 @@ func TestWavelengthRejectsBadGateway(t *testing.T) {
 func TestWavelengthTrackingUnsupported(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewWavelengthInvoiceClient("http://localhost:10061", false)
+	client, err := NewWavelengthInvoiceClient("http://localhost:10061", false, "")
 	require.NoError(t, err)
 
 	_, err = client.ListInvoices(
@@ -221,7 +224,7 @@ func TestWavelengthTrackingUnsupported(t *testing.T) {
 func TestWavelengthGatewayPathJoin(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewWavelengthInvoiceClient("http://localhost:10061/", false)
+	client, err := NewWavelengthInvoiceClient("http://localhost:10061/", false, "")
 	require.NoError(t, err)
 	require.False(t, strings.Contains(client.recvURL, "//v1"))
 	require.True(t, strings.HasSuffix(client.recvURL, "/v1/wallet/recv"))
@@ -308,4 +311,111 @@ func TestWavelengthAddInvoicePrefersValue(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, *body, `"amt_sat":7`)
+}
+
+// TestWavelengthSendsMacaroon checks that a configured macaroon reaches the
+// gateway on the header it forwards into gRPC metadata.
+//
+// Without it the daemon answers 401, AddInvoice fails, and the client waiting
+// for a 402 gets a 500 instead. That is the default state of a wallet daemon:
+// it serves unauthenticated only when started with rpc.no-macaroons, which it
+// refuses outright on mainnet.
+func TestWavelengthSendsMacaroon(t *testing.T) {
+	t.Parallel()
+
+	path, serialized := writeTestMacaroon(t)
+
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Get("macaroon")
+			_, _ = w.Write([]byte(recvBody(
+				"lnbcrt1", testPaymentHash,
+			)))
+		},
+	))
+	t.Cleanup(server.Close)
+
+	client, err := NewWavelengthInvoiceClient(server.URL, false, path)
+	require.NoError(t, err)
+
+	_, err = client.AddInvoice(
+		context.Background(), &lnrpc.Invoice{Value: 11500},
+	)
+	require.NoError(t, err)
+
+	// Hex encoded, which is the form the gateway decodes.
+	require.Equal(t, hex.EncodeToString(serialized), got)
+}
+
+// TestWavelengthOmitsMacaroonWhenUnset checks that leaving the option empty
+// sends no credential at all, rather than an empty one the daemon would have
+// to interpret.
+func TestWavelengthOmitsMacaroonWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	var present bool
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, present = r.Header["Macaroon"]
+			_, _ = w.Write([]byte(recvBody(
+				"lnbcrt1", testPaymentHash,
+			)))
+		},
+	))
+	t.Cleanup(server.Close)
+
+	client, err := NewWavelengthInvoiceClient(server.URL, false, "")
+	require.NoError(t, err)
+
+	_, err = client.AddInvoice(
+		context.Background(), &lnrpc.Invoice{Value: 11500},
+	)
+	require.NoError(t, err)
+
+	require.False(t, present)
+}
+
+// TestWavelengthRejectsBadMacaroon covers the two ways the option is got
+// wrong. Both fail at construction, which is start-up, rather than on the
+// first request a paying client is waiting on.
+func TestWavelengthRejectsBadMacaroon(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewWavelengthInvoiceClient(
+		"http://localhost:10061", false,
+		filepath.Join(t.TempDir(), "absent.macaroon"),
+	)
+	require.ErrorContains(t, err, "read wavelength macaroon")
+
+	// A file that exists but is not a macaroon. Hex encoding would have
+	// accepted it happily and the daemon would have rejected it later as
+	// an authentication failure naming nothing useful.
+	notMac := filepath.Join(t.TempDir(), "tls.cert")
+	require.NoError(t, os.WriteFile(notMac, []byte("not a macaroon"), 0o600))
+
+	_, err = NewWavelengthInvoiceClient(
+		"http://localhost:10061", false, notMac,
+	)
+	require.ErrorContains(t, err, "is not a macaroon")
+}
+
+// writeTestMacaroon writes a serialized macaroon to a temp file, returning its
+// path and the bytes on disk.
+func writeTestMacaroon(t *testing.T) (string, []byte) {
+	t.Helper()
+
+	mac, err := macaroon.New(
+		[]byte("root-key"), []byte("wavelength"), "waved",
+		macaroon.LatestVersion,
+	)
+	require.NoError(t, err)
+
+	serialized, err := mac.MarshalBinary()
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "waved.macaroon")
+	require.NoError(t, os.WriteFile(path, serialized, 0o600))
+
+	return path, serialized
 }

--- a/config.go
+++ b/config.go
@@ -62,6 +62,13 @@ type AuthConfig struct {
 	// LndHost is the hostname of the LND instance to connect to.
 	LndHost string `long:"lndhost" description:"Hostname of the LND instance to connect to"`
 
+	// WavelengthGateway is the base URL of a Wavelength wallet daemon's
+	// HTTP/JSON gateway to mint challenge invoices from, instead of an lnd
+	// node. Invoices from that wallet are backed by an inbound swap, so a
+	// seller configured this way needs no Lightning node, no channels and
+	// no inbound liquidity in order to be paid.
+	WavelengthGateway string `long:"wavelengthgateway" description:"Base URL of a Wavelength wallet daemon's HTTP/JSON gateway to mint invoices from, e.g. http://localhost:10061"`
+
 	TLSPath string `long:"tlspath" description:"Path to LND instance's tls certificate"`
 
 	MacDir string `long:"macdir" description:"Directory containing LND instance's macaroons"`
@@ -113,6 +120,22 @@ func (a *AuthConfig) validate() error {
 	}
 
 	switch {
+	// If WavelengthGateway is set we mint invoices from a Wavelength
+	// wallet daemon and there is no Lightning node in the picture at all.
+	case a.WavelengthGateway != "":
+		log.Info("Validating wavelength configuration")
+
+		// The lnd and lnc fields describe a node this backend does not
+		// use. Silently ignoring them would let a half-migrated config
+		// look like it was still talking to the node it names.
+		if a.LndHost != "" || a.Passphrase != "" {
+			return errors.New("lndhost and passphrase cannot be " +
+				"set when minting invoices from a wavelength " +
+				"wallet")
+		}
+
+		return nil
+
 	// If LndHost is set we connect directly to the LND node.
 	case a.LndHost != "":
 		log.Info("Validating lnd configuration")

--- a/config.go
+++ b/config.go
@@ -69,6 +69,13 @@ type AuthConfig struct {
 	// no inbound liquidity in order to be paid.
 	WavelengthGateway string `long:"wavelengthgateway" description:"Base URL of a Wavelength wallet daemon's HTTP/JSON gateway to mint invoices from, e.g. http://localhost:10061"`
 
+	// WavelengthMacaroonPath is the path to the macaroon authorizing calls
+	// to that gateway. A wallet daemon requires one unless it was started
+	// with rpc.no-macaroons, which it refuses to accept on mainnet, so
+	// leaving this empty only works against a daemon deliberately running
+	// without authentication.
+	WavelengthMacaroonPath string `long:"wavelengthmacaroonpath" description:"Path to the macaroon authorizing calls to the Wavelength wallet daemon's gateway"`
+
 	TLSPath string `long:"tlspath" description:"Path to LND instance's tls certificate"`
 
 	MacDir string `long:"macdir" description:"Directory containing LND instance's macaroons"`

--- a/proxy/cors_test.go
+++ b/proxy/cors_test.go
@@ -3,6 +3,7 @@ package proxy_test
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,13 @@ func startBackendCORS(server *http.Server) error {
 		h.Set("Access-Control-Allow-Origin", "*")
 		h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		h.Set("Access-Control-Allow-Headers", "Content-Type")
+
+		// A header of the backend's own, which only it knows to
+		// expose. Nothing in aperture can guess this belongs on the
+		// list, so it is the case that proves the list is merged
+		// rather than replaced.
+		h.Set("Access-Control-Expose-Headers", "X-Request-Id")
+		h.Set("X-Request-Id", "abc123")
 
 		_, err := w.Write([]byte(testHTTPResponseBody))
 		if err != nil {
@@ -72,10 +80,15 @@ func startCORSProxy(t *testing.T) {
 // TestProxyCORSNotDuplicated tests that a backend setting its own CORS headers
 // does not end up with two of each on the way out.
 //
-// This is not cosmetic. Two Access-Control-Allow-Origin fields is invalid per
-// the fetch standard rather than a repeated "*", so the browser rejects the
-// response and the fetch throws before the caller sees a status code. Command
-// line clients never notice, which is what makes it worth a test.
+// This is not cosmetic for Access-Control-Allow-Origin, which is single
+// valued: two of them is invalid per the fetch standard rather than a repeated
+// "*", so the browser rejects the response and the fetch throws before the
+// caller sees a status code. Command line clients never notice, which is what
+// makes it worth a test.
+//
+// The list-based fields are held to one line for a weaker reason. Repeated
+// lines there are legal, since every reader joins them with ", " before
+// splitting, but a single line is the form with nothing to get wrong.
 func TestProxyCORSNotDuplicated(t *testing.T) {
 	startCORSProxy(t)
 
@@ -142,4 +155,98 @@ func TestProxyCORSPreflightAllowsContentType(t *testing.T) {
 	require.Contains(t, allowed, "Content-Type")
 
 	require.Len(t, resp.Header.Values("Access-Control-Allow-Origin"), 1)
+}
+
+// TestProxyCORSKeepsBackendExposedHeaders tests that a backend's own entries in
+// the list based CORS fields survive the trip through the proxy.
+//
+// Access-Control-Expose-Headers is what a service uses to say which of its
+// response headers JS is allowed to read. Only the backend knows that list.
+// Overwriting it with aperture's own entries would leave every such header
+// unreadable from the browser the moment the service moved behind the proxy,
+// and the failure is silent: headers.get() returns null rather than raising,
+// so it reads as the backend having stopped sending the header at all.
+func TestProxyCORSKeepsBackendExposedHeaders(t *testing.T) {
+	startCORSProxy(t)
+
+	req, err := http.NewRequest(
+		"GET", fmt.Sprintf("http://%s/api/test", testProxyAddr), nil,
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// One field line, carrying the backend's entry alongside ours.
+	exposed := resp.Header.Values("Access-Control-Expose-Headers")
+	require.Len(t, exposed, 1)
+
+	entries := splitCORSList(exposed[0])
+	require.Contains(t, entries, "X-Request-Id")
+	require.Contains(t, entries, "WWW-Authenticate")
+	require.Contains(t, entries, "Payment-Receipt")
+
+	// The backend's entry keeps its place at the front, so the list reads
+	// in the order that service published it.
+	require.Equal(t, "X-Request-Id", entries[0])
+}
+
+// TestProxyCORSDoesNotRepeatSharedEntries tests that an entry both the backend
+// and aperture name appears once rather than twice.
+//
+// The backend stub sets Access-Control-Allow-Headers: Content-Type, which is
+// also on aperture's list. A naive append would emit it twice. That is
+// harmless to a browser, which dedupes on read, but it grows without bound
+// across any future layer that does the same thing.
+func TestProxyCORSDoesNotRepeatSharedEntries(t *testing.T) {
+	startCORSProxy(t)
+
+	req, err := http.NewRequest(
+		"GET", fmt.Sprintf("http://%s/api/test", testProxyAddr), nil,
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	allowed := splitCORSList(
+		resp.Header.Get("Access-Control-Allow-Headers"),
+	)
+
+	var contentTypes int
+	for _, entry := range allowed {
+		if strings.EqualFold(entry, "Content-Type") {
+			contentTypes++
+		}
+	}
+	require.Equal(t, 1, contentTypes, "got %v", allowed)
+
+	// Same for the methods, every one of which the backend also names.
+	methods := splitCORSList(
+		resp.Header.Get("Access-Control-Allow-Methods"),
+	)
+	require.ElementsMatch(
+		t, []string{"GET", "POST", "OPTIONS"}, methods,
+	)
+}
+
+// splitCORSList splits a list based header field value into its entries.
+func splitCORSList(value string) []string {
+	var entries []string
+	for _, entry := range strings.Split(value, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
 }

--- a/proxy/cors_test.go
+++ b/proxy/cors_test.go
@@ -1,0 +1,145 @@
+package proxy_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/aperture/auth"
+	"github.com/lightninglabs/aperture/proxy"
+	"github.com/stretchr/testify/require"
+)
+
+// corsBackendAddr is a separate listen address so these tests can run
+// alongside the others without fighting over a port.
+const corsBackendAddr = "localhost:8087"
+
+// startBackendCORS starts a backend that sets its own CORS headers, the way any
+// service that can also be reached directly will. The proxy runs its own CORS
+// logic over whatever comes back from here.
+func startBackendCORS(server *http.Server) error {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Access-Control-Allow-Origin", "*")
+		h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		h.Set("Access-Control-Allow-Headers", "Content-Type")
+
+		_, err := w.Write([]byte(testHTTPResponseBody))
+		if err != nil {
+			panic(err)
+		}
+	}
+	server.Handler = http.HandlerFunc(handler)
+
+	return server.ListenAndServe()
+}
+
+// startCORSProxy brings up a proxy with auth off in front of a backend that
+// sets its own CORS headers, and returns once both are accepting connections.
+func startCORSProxy(t *testing.T) {
+	t.Helper()
+
+	services := []*proxy.Service{{
+		Address:    corsBackendAddr,
+		HostRegexp: testHostRegexp,
+		PathRegexp: "^/api/.*$",
+		Protocol:   "http",
+		Auth:       "off",
+	}}
+
+	p, err := proxy.New(auth.NewMockAuthenticator(), services, nil, nil)
+	require.NoError(t, err)
+
+	server := &http.Server{
+		Addr:    testProxyAddr,
+		Handler: http.HandlerFunc(p.ServeHTTP),
+	}
+	go func() {
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			t.Errorf("proxy serve error: %v", err)
+		}
+	}()
+	t.Cleanup(func() { closeOrFail(t, server) })
+
+	backend := &http.Server{Addr: corsBackendAddr}
+	go func() { _ = startBackendCORS(backend) }()
+	t.Cleanup(func() { closeOrFail(t, backend) })
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestProxyCORSNotDuplicated tests that a backend setting its own CORS headers
+// does not end up with two of each on the way out.
+//
+// This is not cosmetic. Two Access-Control-Allow-Origin fields is invalid per
+// the fetch standard rather than a repeated "*", so the browser rejects the
+// response and the fetch throws before the caller sees a status code. Command
+// line clients never notice, which is what makes it worth a test.
+func TestProxyCORSNotDuplicated(t *testing.T) {
+	startCORSProxy(t)
+
+	req, err := http.NewRequest(
+		"GET", fmt.Sprintf("http://%s/api/test", testProxyAddr), nil,
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Exactly one of each, no matter that the backend set them too.
+	corsFields := []string{
+		"Access-Control-Allow-Origin",
+		"Access-Control-Allow-Methods",
+		"Access-Control-Allow-Headers",
+		"Access-Control-Expose-Headers",
+	}
+	for _, field := range corsFields {
+		require.Len(
+			t, resp.Header.Values(field), 1,
+			"expected exactly one %s", field,
+		)
+	}
+
+	require.Equal(
+		t, "*", resp.Header.Get("Access-Control-Allow-Origin"),
+	)
+}
+
+// TestProxyCORSPreflightAllowsContentType tests that the preflight the proxy
+// answers itself permits a JSON request body.
+//
+// A POST carrying application/json is not a simple request, so the browser
+// preflights it. The proxy short circuits OPTIONS without ever asking the
+// backend, so if Content-Type is missing from the allowed set here, every JSON
+// API behind the proxy is unreachable from a browser regardless of what the
+// backend would have said.
+func TestProxyCORSPreflightAllowsContentType(t *testing.T) {
+	startCORSProxy(t)
+
+	req, err := http.NewRequest(
+		"OPTIONS", fmt.Sprintf("http://%s/api/test", testProxyAddr),
+		nil,
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	allowed := resp.Header.Get("Access-Control-Allow-Headers")
+	require.Contains(t, allowed, "Content-Type")
+
+	require.Len(t, resp.Header.Values("Access-Control-Allow-Origin"), 1)
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -663,16 +663,29 @@ func matchService(req *http.Request, services []*Service) (*Service, bool) {
 // Resource Sharing. These header fields are needed to signal to the browser
 // that it's ok to allow requests to sub domains, even if the JS was served from
 // the top level domain.
+//
+// Every field is set rather than added, because this runs over the backend's
+// own response headers on the way out. A backend that sets its own CORS
+// headers, which any service that can also be reached directly will do, would
+// otherwise end up with two of each. Two Access-Control-Allow-Origin fields is
+// not a more emphatic "*", it is invalid per the fetch standard, and the
+// browser rejects the response outright. Aperture sits in front, so its view
+// wins.
 func addCorsHeaders(header http.Header) {
 	log.Debugf("Adding CORS headers to response.")
 
-	header.Add("Access-Control-Allow-Origin", "*")
-	header.Add("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	header.Add("Access-Control-Expose-Headers",
+	header.Set("Access-Control-Allow-Origin", "*")
+	header.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	header.Set("Access-Control-Expose-Headers",
 		"WWW-Authenticate, Payment-Receipt")
-	header.Add(
+
+	// Content-Type has to be allowed for any JSON API behind the proxy. A
+	// POST carrying application/json is not a simple request, so the
+	// browser preflights it, and we answer that preflight ourselves
+	// without ever consulting the backend.
+	header.Set(
 		"Access-Control-Allow-Headers",
-		"Authorization, Grpc-Metadata-macaroon, "+
+		"Content-Type, Authorization, Grpc-Metadata-macaroon, "+
 			"WWW-Authenticate, Payment-Receipt",
 	)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -664,30 +664,86 @@ func matchService(req *http.Request, services []*Service) (*Service, bool) {
 // that it's ok to allow requests to sub domains, even if the JS was served from
 // the top level domain.
 //
-// Every field is set rather than added, because this runs over the backend's
-// own response headers on the way out. A backend that sets its own CORS
-// headers, which any service that can also be reached directly will do, would
-// otherwise end up with two of each. Two Access-Control-Allow-Origin fields is
-// not a more emphatic "*", it is invalid per the fetch standard, and the
-// browser rejects the response outright. Aperture sits in front, so its view
-// wins.
+// This runs over the backend's own response headers on the way out, and a
+// backend that sets its own CORS headers, which any service that can also be
+// reached directly will do, would otherwise end up with two of each. What that
+// duplication means depends on the field, so the two kinds are handled
+// differently.
+//
+// Access-Control-Allow-Origin is single-valued. Two of them is not a more
+// emphatic "*", it is invalid per the fetch standard and the browser rejects
+// the response outright, so aperture's view replaces whatever was there.
+//
+// The other three are list-based fields. Per RFC 9110 repeated field lines are
+// combined with ", " and the fetch standard's "get, decode, and split" reads
+// them as one list, so a duplicate there was never invalid: it merged. Which
+// means replacing them would silently drop the backend's own entries, and a
+// backend exposing Access-Control-Expose-Headers: X-Request-Id would find that
+// header unreadable from JS the moment it moved behind aperture. So aperture's
+// entries are merged into whatever the backend already asked for.
 func addCorsHeaders(header http.Header) {
 	log.Debugf("Adding CORS headers to response.")
 
 	header.Set("Access-Control-Allow-Origin", "*")
-	header.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	header.Set("Access-Control-Expose-Headers",
-		"WWW-Authenticate, Payment-Receipt")
+
+	mergeCorsList(header, "Access-Control-Allow-Methods",
+		"GET", "POST", "OPTIONS")
+	mergeCorsList(header, "Access-Control-Expose-Headers",
+		"WWW-Authenticate", "Payment-Receipt")
 
 	// Content-Type has to be allowed for any JSON API behind the proxy. A
 	// POST carrying application/json is not a simple request, so the
 	// browser preflights it, and we answer that preflight ourselves
 	// without ever consulting the backend.
-	header.Set(
-		"Access-Control-Allow-Headers",
-		"Content-Type, Authorization, Grpc-Metadata-macaroon, "+
-			"WWW-Authenticate, Payment-Receipt",
+	mergeCorsList(
+		header, "Access-Control-Allow-Headers",
+		"Content-Type", "Authorization", "Grpc-Metadata-macaroon",
+		"WWW-Authenticate", "Payment-Receipt",
 	)
+}
+
+// mergeCorsList adds the given entries to a list-based CORS header field,
+// keeping whatever the backend already put there and skipping any entry it had
+// already named. The result is written as a single field line, which is the
+// unambiguous form: repeated lines are legal here but only because every
+// reader has to join them first, and there is no reason to make them.
+//
+// Matching is case-insensitive because header names are, and a backend that
+// wrote "content-type" means the same thing we do.
+func mergeCorsList(header http.Header, field string, entries ...string) {
+	var (
+		merged []string
+		seen   = make(map[string]struct{})
+	)
+
+	add := func(entry string) {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return
+		}
+
+		key := strings.ToLower(entry)
+		if _, ok := seen[key]; ok {
+			return
+		}
+
+		seen[key] = struct{}{}
+		merged = append(merged, entry)
+	}
+
+	// The backend's own entries come first, so a browser reading the list
+	// sees them in the order that service published them.
+	for _, line := range header.Values(field) {
+		for _, entry := range strings.Split(line, ",") {
+			add(entry)
+		}
+	}
+
+	for _, entry := range entries {
+		add(entry)
+	}
+
+	header.Set(field, strings.Join(merged, ", "))
 }
 
 // freshChallengeHeader mints a challenge quoting the given set of prices,

--- a/proxy/session_metering_test.go
+++ b/proxy/session_metering_test.go
@@ -92,12 +92,10 @@ type fakeSessionSettler struct {
 	settlements chan settlement
 }
 
-func newFakeSessionSettler(sessionID string,
-	charged int64) *fakeSessionSettler {
-
+func newFakeSessionSettler() *fakeSessionSettler {
 	return &fakeSessionSettler{
-		sessionID:   sessionID,
-		charged:     charged,
+		sessionID:   "session-abc",
+		charged:     7,
 		present:     true,
 		settlements: make(chan settlement, 1),
 	}
@@ -228,7 +226,7 @@ func TestCheckSessionMeteringAnnotates(t *testing.T) {
 	t.Parallel()
 
 	fake := newFakeSessionPricer()
-	settler := newFakeSessionSettler("session-abc", 7)
+	settler := newFakeSessionSettler()
 
 	p := &Proxy{authenticator: settler}
 	target := newSessionService(fake)
@@ -292,7 +290,7 @@ func TestCheckSessionMeteringSkips(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			settler := newFakeSessionSettler("session-abc", 7)
+			settler := newFakeSessionSettler()
 			p := &Proxy{authenticator: settler}
 			target := newSessionService(newFakeSessionPricer())
 			tc.setup(p, target, settler)
@@ -378,7 +376,7 @@ func TestSessionSettlementOnCompletedResponse(t *testing.T) {
 	fake := newFakeSessionPricer()
 	fake.cost = 19
 
-	settler := newFakeSessionSettler("session-abc", 7)
+	settler := newFakeSessionSettler()
 	res := sessionResponse(
 		t, sessionInfo(fake, settler), http.StatusOK,
 		"data: {\"usage\":{\"total_tokens\":40}}\n\ndata: [DONE]\n\n",
@@ -389,6 +387,7 @@ func TestSessionSettlementOnCompletedResponse(t *testing.T) {
 	drained, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(drained), "[DONE]")
+	require.NoError(t, res.Body.Close())
 
 	usage := requireSettlement(t, fake)
 	require.Equal(t, "session-abc", usage.SessionID)
@@ -415,7 +414,7 @@ func TestSessionSettlementOnAbortedResponse(t *testing.T) {
 	fake := newFakeSessionPricer()
 	fake.cost = 3
 
-	settler := newFakeSessionSettler("session-abc", 7)
+	settler := newFakeSessionSettler()
 	res := sessionResponse(
 		t, sessionInfo(fake, settler), http.StatusOK,
 		"data: {\"choices\":[]}\n\n",
@@ -442,7 +441,7 @@ func TestSessionSettlementIsExactlyOnce(t *testing.T) {
 	fake := newFakeSessionPricer()
 	fake.cost = 5
 
-	settler := newFakeSessionSettler("session-abc", 7)
+	settler := newFakeSessionSettler()
 	res := sessionResponse(
 		t, sessionInfo(fake, settler), http.StatusOK, "data: [DONE]\n\n",
 	)
@@ -481,7 +480,7 @@ func TestSessionSettlementLeavesEstimateOnPricerFailure(t *testing.T) {
 			fake := newFakeSessionPricer()
 			fake.settleErr = status.Error(code, "no")
 
-			settler := newFakeSessionSettler("session-abc", 7)
+			settler := newFakeSessionSettler()
 			res := sessionResponse(
 				t, sessionInfo(fake, settler), http.StatusOK,
 				"data: [DONE]\n\n",
@@ -490,6 +489,7 @@ func TestSessionSettlementLeavesEstimateOnPricerFailure(t *testing.T) {
 			attachSessionObserver(res)
 			_, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
+			require.NoError(t, res.Body.Close())
 
 			requireSettlement(t, fake)
 
@@ -511,11 +511,14 @@ func TestSessionObserverSkipsProtocolUpgrade(t *testing.T) {
 	t.Parallel()
 
 	fake := newFakeSessionPricer()
-	settler := newFakeSessionSettler("session-abc", 7)
+	settler := newFakeSessionSettler()
 
 	res := sessionResponse(
 		t, sessionInfo(fake, settler), http.StatusSwitchingProtocols, "",
 	)
+	t.Cleanup(func() {
+		require.NoError(t, res.Body.Close())
+	})
 
 	attachSessionObserver(res)
 


### PR DESCRIPTION
In this PR, we let aperture take its challenge invoices from a Wavelength wallet daemon instead of an lnd node, so a seller can charge for a service without running Lightning infrastructure at all.

The motivation is what the seller no longer has to operate. An invoice minted through walletdk's `Recv` is backed by an inbound swap: the swap server supplies the inbound liquidity and settles the payment into the wallet's Ark balance. The seller therefore needs no Lightning node, no channels, and no inbound capacity, which is usually the most annoying part of standing an L402 seller up.

Configuration is one line in place of three:

```yaml
authenticator:
  network: "regtest"
  wavelengthgateway: "http://localhost:10061"
  # no lndhost, no tlspath, no macdir
```

## How it hangs together

We hang this off the existing `InvoiceClient` seam rather than writing a second `Challenger`, so `LndChallenger` keeps owning the mint and verify logic and the new code is only a transport. `AddInvoice` posts to the wallet's `/v1/wallet/recv` and maps the reply back onto `lnrpc.AddInvoiceResponse`. The wallet returns the payment hash next to the payment request, so we read it from there rather than decoding the bolt11, and the two can never disagree about which hash the challenge commits to.

## On strictverify

`strictverify` is refused at construction rather than ignored. Strict verification means refusing a token whose invoice was never seen to settle, and `LndChallenger` implements that by listing and subscribing to invoices, neither of which this backend can do. Accepting the flag would leave aperture believing it was verifying settlement when it was not, and the symptom would be tokens honoured for invoices nobody paid. `ListInvoices` and `SubscribeInvoices` return errors for the same reason: answering with an empty list would read to the challenger as "no such invoice".

That does mean this backend is currently non-strict only, i.e. it trusts that possession of the preimage implies payment. That is the same assumption the lnd backend makes under the default `strictverify: false`. Wiring settlement lookups through the wallet's entry stream would lift the restriction and is the obvious follow-up.

## Testing

Unit tests cover the happy path, the millisatoshi fallback, a wallet error reaching the operator intact, malformed and short payment hashes, the `strictverify` guard, gateway URL validation, and the unsupported tracking methods.

It has also been run end to end on regtest against a real OpenAI-compatible upstream, driven by an external buyer client, with a metered dynamic pricer minting prepaid token bundles. A cold start minted an 11,500 sat challenge from the seller's wallet, the buyer paid it, and the balances moved exactly (buyer 52,000 to 40,500, seller 0 to 11,500, zero fee) with the receipt's preimage verifying against the payment hash.

The interesting part of that run: both ends were Ark wallets on the same operator, so the payment settled as an in-ark vHTLC carrying the invoice's own payment hash rather than routing over Lightning. The preimage still came back, so L402's proof-of-payment held over a path with no Lightning hop in it at all.
