### PR TITLE
proxy: make rate limiting atomic and update-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ unauthenticated requests.
   regular expressions.
 * **Multiple rules**: All matching rules are evaluated; if any rule denies the
   request, it is rejected. This allows layering global and endpoint-specific
-  limits.
+  limits, or multiple time horizons for the same path expression. A rejected
+  request does not consume capacity from any matching rule.
 * **Protocol-aware responses**: Returns HTTP 429 with `Retry-After` header for
   REST requests, and gRPC `ResourceExhausted` status for gRPC requests.
 
@@ -228,3 +229,29 @@ request is rejected. This allows clients to make quick bursts of requests (up to
 | `requests` | Number of requests allowed per time window. | Yes |
 | `per` | Time window duration (e.g., `1s`, `1m`, `1h`). | Yes |
 | `burst` | Maximum burst size. Defaults to `requests` if not set. | No |
+
+### Enforcement Scope
+
+Rate limiting is an in-process abuse control rather than a distributed quota:
+
+* Each Aperture process keeps independent buckets. Deploying multiple replicas
+  multiplies the effective allowance unless requests use consistent routing.
+* Buckets are held in an LRU cache that defaults to 10,000 entries. Buckets are
+  not persisted. Restarting Aperture, updating a service, or evicting a
+  client-rule entry creates a fresh bucket with full burst capacity. Each
+  matching rule consumes one cache entry per client. A request that matches
+  more rules than the configured cache capacity is rejected because its state
+  cannot be retained safely.
+* Limits are per client; a rule without `pathregexp` covers every path but is
+  still not an aggregate limit shared by all clients.
+* Authenticated L402 requests are keyed by token ID. Auth-whitelisted,
+  authentication-disabled, zero-priced, and other unauthenticated requests are
+  keyed by the masked direct peer IP. Payment/MPP credentials currently also
+  fall back to that IP key.
+* Aperture uses the connection's direct peer address and does not trust
+  forwarded-IP headers. Deployments behind a load balancer should preserve the
+  original source address or account for clients sharing the load balancer's
+  bucket.
+* Authentication is validated before the authenticated token bucket is
+  checked. The limiter protects backend request handling, but does not bound
+  authentication or challenge-generation work.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -297,8 +297,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// If the price returned is zero, then break out of the
-			// switch statement and allow access to the service.
+			// switch statement and allow access to the service. The
+			// request is unauthenticated, so rate limit it by IP first.
 			if price == 0 {
+				if !checkRateLimit(false) {
+					return
+				}
+
 				break
 			}
 
@@ -363,10 +368,15 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-				// If the price returned is zero, then break
-				// out of the switch statement and allow access
-				// to the service.
+				// If the price returned is zero, then break out of
+				// the switch statement and allow access to the
+				// service. The request is unauthenticated, so rate
+				// limit it by IP first.
 				if price == 0 {
+					if !checkRateLimit(false) {
+						return
+					}
+
 					break
 				}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -146,7 +146,6 @@ func New(auth auth.Authenticator, services []*Service,
 		priorityLocalServices: priorityLocalServices,
 		localServices:         localServices,
 		authenticator:         auth,
-		services:              services,
 		blocklist:             blMap,
 	}
 	err := proxy.UpdateServices(services)
@@ -473,13 +472,22 @@ func (p *Proxy) acceptForService(header *http.Header, resourceName string,
 
 // UpdateServices re-configures the proxy to use a new set of backend services.
 func (p *Proxy) UpdateServices(services []*Service) error {
-	err := prepareServices(services)
+	preparedServices, err := cloneServices(services)
 	if err != nil {
 		return err
 	}
 
-	certPool, err := certPool(services)
+	err = prepareServices(preparedServices)
 	if err != nil {
+		closePreparedServicePricers(preparedServices)
+
+		return err
+	}
+
+	certPool, err := certPool(preparedServices)
+	if err != nil {
+		closePreparedServicePricers(preparedServices)
+
 		return err
 	}
 	transport := &http.Transport{
@@ -493,7 +501,8 @@ func (p *Proxy) UpdateServices(services []*Service) error {
 	p.servicesMtx.Lock()
 	defer p.servicesMtx.Unlock()
 
-	p.services = services
+	copyPreparedServiceConfig(services, preparedServices)
+	p.services = preparedServices
 
 	p.proxyBackend = &httputil.ReverseProxy{
 		Director:  p.director,
@@ -555,6 +564,21 @@ func (p *Proxy) UpdateServices(services []*Service) error {
 	}
 
 	return nil
+}
+
+// closePreparedServicePricers releases pricers created for a service snapshot
+// that could not be published.
+func closePreparedServicePricers(services []*Service) {
+	for _, service := range services {
+		if service == nil || service.pricer == nil {
+			continue
+		}
+
+		if err := service.pricer.Close(); err != nil {
+			log.Errorf("Unable to close unpublished pricer for service "+
+				"%s: %v", service.Name, err)
+		}
+	}
 }
 
 // Close cleans up the Proxy by closing any remaining open connections.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -501,6 +501,7 @@ func (p *Proxy) UpdateServices(services []*Service) error {
 	p.servicesMtx.Lock()
 	defer p.servicesMtx.Unlock()
 
+	oldServices := p.services
 	copyPreparedServiceConfig(services, preparedServices)
 	p.services = preparedServices
 
@@ -563,6 +564,8 @@ func (p *Proxy) UpdateServices(services []*Service) error {
 		FlushInterval: -1,
 	}
 
+	resetRateLimitCacheMetrics(oldServices, preparedServices)
+
 	return nil
 }
 
@@ -581,6 +584,14 @@ func closePreparedServicePricers(services []*Service) {
 	}
 }
 
+// resetRateLimitCacheMetrics replaces the active limiters' contributions to the
+// process-wide cache gauge while the service write lock is held. At this point
+// all requests using the old snapshot have drained, so an old limiter cannot
+// publish another size after being removed.
+func resetRateLimitCacheMetrics(oldServices, newServices []*Service) {
+	managedRateLimitCacheMetrics.replace(oldServices, newServices)
+}
+
 // Close cleans up the Proxy by closing any remaining open connections.
 func (p *Proxy) Close() error {
 	p.servicesMtx.RLock()
@@ -588,6 +599,10 @@ func (p *Proxy) Close() error {
 
 	var returnErr error
 	for _, s := range p.services {
+		if s.rateLimiter != nil {
+			s.rateLimiter.removeCacheMetric()
+		}
+
 		if err := s.pricer.Close(); err != nil {
 			log.Errorf("error while closing the pricer of "+
 				"service %s: %v", s.Name, err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -242,23 +242,37 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// accordingly.
 	authLevel := target.AuthRequired(r)
 
-	// checkRateLimit is a helper that checks rate limits after determining
-	// the authentication status. This ensures we only use L402 token IDs
-	// for authenticated requests, preventing DoS via garbage tokens.
-	checkRateLimit := func(authenticated bool) bool {
+	// reserveRateLimit provisionally admits a request. Most paths commit
+	// immediately through checkRateLimit; the freebie path can cancel the
+	// admission if updating its quota store fails.
+	reserveRateLimit := func(authenticated bool) (*rateLimitAdmission, bool) {
 		if target.rateLimiter == nil {
-			return true
+			return nil, true
 		}
 		key := ExtractRateLimitKey(r, remoteIP, authenticated)
-		allowed, retryAfter := target.rateLimiter.Allow(r, key)
+		admission, allowed, retryAfter := target.rateLimiter.reserve(r, key)
 		if !allowed {
-			prefixLog.Infof("Rate limit exceeded for key %s, "+
-				"retry after %v", key, retryAfter)
+			prefixLog.Infof("Rate limit exceeded, retry after %v",
+				retryAfter)
 			addCorsHeaders(w.Header())
 			sendRateLimitResponse(w, r, retryAfter)
 		}
 
-		return allowed
+		return admission, allowed
+	}
+
+	// checkRateLimit is a helper that checks rate limits after determining
+	// the authentication status. This ensures we only use L402 token IDs
+	// for authenticated requests, preventing DoS via garbage tokens.
+	checkRateLimit := func(authenticated bool) bool {
+		admission, allowed := reserveRateLimit(authenticated)
+		if !allowed {
+			return false
+		}
+
+		admission.Commit()
+
+		return true
 	}
 
 	skipInvoiceCreation := target.SkipInvoiceCreation(r)
@@ -385,7 +399,27 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				)
 				return
 			}
-			_, err = target.freebieDB.TallyFreebie(r, remoteIP)
+			// Provisionally reserve rate-limit capacity before tallying the
+			// freebie so a rejected request does not consume both quotas. Keep
+			// the defensive cancellation in this short-lived function so the
+			// admission isn't retained across the backend response.
+			var allowed bool
+			allowed, err = func() (bool, error) {
+				admission, allowed := reserveRateLimit(false)
+				if !allowed {
+					return false, nil
+				}
+				defer admission.Cancel()
+
+				_, err := target.freebieDB.TallyFreebie(r, remoteIP)
+				if err != nil {
+					return false, err
+				}
+
+				admission.Commit()
+
+				return true, nil
+			}()
 			if err != nil {
 				prefixLog.Errorf("Error updating freebie db: "+
 					"%v", err)
@@ -395,11 +429,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				)
 				return
 			}
-
-			// Unauthenticated freebie user, rate limit by IP.
-			if !checkRateLimit(false) {
+			if !allowed {
 				return
 			}
+
 		} else {
 			// Authenticated user on freebie path. Inject receipt
 			// headers and apply rate limit by L402 token.

--- a/proxy/ratelimit_config.go
+++ b/proxy/ratelimit_config.go
@@ -14,7 +14,7 @@ type RateLimitConfig struct {
 	// Requests is the number of requests allowed per time window (Per).
 	Requests int `long:"requests" description:"Number of requests allowed per time window"`
 
-	// Per is the time window duration (e.g., 1s, 1m, 1h). Defaults to 1s.
+	// Per is the required time window duration (e.g., 1s, 1m, 1h).
 	Per time.Duration `long:"per" description:"Time window for rate limiting (e.g., 1s, 1m, 1h)"`
 
 	// Burst is the maximum number of requests that can be made in a burst,

--- a/proxy/ratelimit_metrics.go
+++ b/proxy/ratelimit_metrics.go
@@ -28,6 +28,39 @@ var (
 		[]string{"service", "path_pattern"},
 	)
 
+	// rateLimitRuleAllowed is the rule-specific counterpart to
+	// rateLimitAllowed. Keeping this as a separate metric preserves the
+	// original path-aggregated series while making duplicate path patterns
+	// with different time horizons distinguishable.
+	rateLimitRuleAllowed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "aperture",
+			Subsystem: "ratelimit",
+			Name:      "rule_allowed_total",
+			Help: "Total allowed evaluations for each configured " +
+				"rate limit rule",
+		},
+		[]string{
+			"service", "path_pattern", "requests", "per", "burst",
+		},
+	)
+
+	// rateLimitRuleDenied records denials for each semantically distinct rule.
+	// Definition labels keep a series' meaning stable across configuration
+	// reordering and distinguish duplicate path patterns with different limits.
+	rateLimitRuleDenied = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "aperture",
+			Subsystem: "ratelimit",
+			Name:      "rule_denied_total",
+			Help: "Total denied evaluations for each configured " +
+				"rate limit rule",
+		},
+		[]string{
+			"service", "path_pattern", "requests", "per", "burst",
+		},
+	)
+
 	// rateLimitCacheSize tracks the current size of the rate limiter cache.
 	rateLimitCacheSize = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/proxy/ratelimit_metrics.go
+++ b/proxy/ratelimit_metrics.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -72,6 +74,20 @@ var (
 		[]string{"service"},
 	)
 
+	// rateLimitActiveCacheSize tracks the aggregate cache size of active
+	// service snapshots. Unlike the legacy last-writer cache_size gauge, this
+	// metric has an explicit update/removal lifecycle.
+	rateLimitActiveCacheSize = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "aperture",
+			Subsystem: "ratelimit",
+			Name:      "active_cache_size",
+			Help: "Current number of rate limiter cache entries across " +
+				"active service snapshots",
+		},
+		[]string{"service"},
+	)
+
 	// rateLimitEvictions counts LRU cache evictions.
 	rateLimitEvictions = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -83,3 +99,156 @@ var (
 		[]string{"service"},
 	)
 )
+
+// cacheSizeMetricRegistry aggregates cache sizes for active managed limiters.
+// Prometheus labels identify services rather than Proxy instances, so deleting
+// or overwriting a label directly would corrupt the gauge when more than one
+// Proxy in the process uses the same service name.
+type cacheSizeMetricRegistry struct {
+	mu sync.Mutex
+
+	limiters map[string]map[*RateLimiter]int
+	totals   map[string]int
+}
+
+var managedRateLimitCacheMetrics = &cacheSizeMetricRegistry{
+	limiters: make(map[string]map[*RateLimiter]int),
+	totals:   make(map[string]int),
+}
+
+// set publishes one managed limiter's size and updates its service aggregate.
+func (r *cacheSizeMetricRegistry) set(limiter *RateLimiter, size int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !limiter.cacheMetricActive.Load() {
+		return
+	}
+
+	serviceName := limiter.serviceName
+	serviceLimiters := r.limiters[serviceName]
+	if serviceLimiters == nil {
+		serviceLimiters = make(map[*RateLimiter]int)
+		r.limiters[serviceName] = serviceLimiters
+	}
+
+	oldSize := serviceLimiters[limiter]
+	serviceLimiters[limiter] = size
+	r.totals[serviceName] += size - oldSize
+	rateLimitActiveCacheSize.WithLabelValues(serviceName).Set(
+		float64(r.totals[serviceName]),
+	)
+}
+
+// remove stops accounting for one managed limiter without disturbing other
+// Proxy instances that use the same service label.
+func (r *cacheSizeMetricRegistry) remove(limiter *RateLimiter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	serviceName := limiter.serviceName
+	serviceLimiters := r.limiters[serviceName]
+	if serviceLimiters == nil {
+		return
+	}
+
+	size, ok := serviceLimiters[limiter]
+	if !ok {
+		return
+	}
+
+	delete(serviceLimiters, limiter)
+	r.totals[serviceName] -= size
+	if len(serviceLimiters) == 0 {
+		delete(r.limiters, serviceName)
+		delete(r.totals, serviceName)
+		rateLimitActiveCacheSize.DeleteLabelValues(serviceName)
+		return
+	}
+
+	rateLimitActiveCacheSize.WithLabelValues(serviceName).Set(
+		float64(r.totals[serviceName]),
+	)
+}
+
+// replace swaps one Proxy snapshot's limiter contributions under one registry
+// lock and publishes each touched service aggregate only after the complete
+// replacement has been calculated.
+func (r *cacheSizeMetricRegistry) replace(oldServices,
+	newServices []*Service) {
+
+	type limiterSize struct {
+		limiter *RateLimiter
+		size    int
+	}
+	newLimiters := make([]limiterSize, 0, len(newServices))
+	for _, service := range newServices {
+		if service == nil || service.rateLimiter == nil ||
+			!service.rateLimiter.managedCacheMetric {
+
+			continue
+		}
+
+		newLimiters = append(newLimiters, limiterSize{
+			limiter: service.rateLimiter,
+			size:    service.rateLimiter.Size(),
+		})
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	touched := make(map[string]struct{})
+	for _, service := range oldServices {
+		if service == nil || service.rateLimiter == nil ||
+			!service.rateLimiter.managedCacheMetric {
+
+			continue
+		}
+
+		limiter := service.rateLimiter
+		limiter.cacheMetricActive.Store(false)
+		serviceLimiters := r.limiters[limiter.serviceName]
+		if serviceLimiters == nil {
+			continue
+		}
+
+		size, ok := serviceLimiters[limiter]
+		if !ok {
+			continue
+		}
+
+		delete(serviceLimiters, limiter)
+		r.totals[limiter.serviceName] -= size
+		touched[limiter.serviceName] = struct{}{}
+		if len(serviceLimiters) == 0 {
+			delete(r.limiters, limiter.serviceName)
+			delete(r.totals, limiter.serviceName)
+		}
+	}
+
+	for _, entry := range newLimiters {
+		limiter := entry.limiter
+		limiter.cacheMetricActive.Store(true)
+		serviceLimiters := r.limiters[limiter.serviceName]
+		if serviceLimiters == nil {
+			serviceLimiters = make(map[*RateLimiter]int)
+			r.limiters[limiter.serviceName] = serviceLimiters
+		}
+
+		serviceLimiters[limiter] = entry.size
+		r.totals[limiter.serviceName] += entry.size
+		touched[limiter.serviceName] = struct{}{}
+	}
+
+	for serviceName := range touched {
+		total, ok := r.totals[serviceName]
+		if !ok {
+			rateLimitActiveCacheSize.DeleteLabelValues(serviceName)
+			continue
+		}
+
+		rateLimitActiveCacheSize.WithLabelValues(serviceName).Set(
+			float64(total),
+		)
+	}
+}

--- a/proxy/ratelimiter.go
+++ b/proxy/ratelimiter.go
@@ -19,15 +19,14 @@ const (
 	DefaultMaxCacheSize = 10_000
 )
 
-// limiterKey is a composite key for the rate limiter cache. Using a struct
-// instead of a concatenated string saves memory because the pathPattern field
-// can reference the same underlying string across multiple keys.
+// limiterKey is a composite key for the rate limiter cache.
 type limiterKey struct {
 	// clientKey identifies the client (e.g., "ip:1.2.3.4" or "token:abc").
 	clientKey string
-	// pathPattern is the rate limit rule's PathRegexp (pointer to config's
-	// string, not a copy).
-	pathPattern string
+	// ruleIndex identifies a rule within the service configuration. The
+	// index, rather than PathRegexp, keeps rules with identical patterns
+	// independent.
+	ruleIndex int
 }
 
 // limiterEntry holds a rate.Limiter. Implements cache.Value interface.
@@ -106,18 +105,18 @@ func (rl *RateLimiter) Allow(r *http.Request, key string) (bool,
 	}
 	reservations := make([]ruleReservation, 0, len(rl.configs))
 
-	for _, cfg := range rl.configs {
+	for ruleIndex, cfg := range rl.configs {
 		if !cfg.Matches(path) {
 			continue
 		}
 
-		// Create composite key: client key + path pattern for
-		// independent limiting per rule. Using a struct instead of
-		// string concatenation saves memory since pathPattern
-		// references the config's string.
+		// Create a composite key for independent limiting per rule. The
+		// rule index is intentionally part of the identity because
+		// multiple limits with different time horizons can legitimately
+		// use the same path pattern.
 		cacheKey := limiterKey{
-			clientKey:   key,
-			pathPattern: cfg.PathRegexp,
+			clientKey: key,
+			ruleIndex: ruleIndex,
 		}
 
 		limiter := rl.getOrCreateLimiter(cacheKey, cfg)

--- a/proxy/ratelimiter.go
+++ b/proxy/ratelimiter.go
@@ -49,6 +49,7 @@ type clientLock struct {
 type clientLockSet struct {
 	mu    sync.Mutex
 	locks map[string]*clientLock
+	pool  sync.Pool
 }
 
 // lock acquires and returns the lock for key. Callers must pass the returned
@@ -61,7 +62,12 @@ func (s *clientLockSet) lock(key string) *clientLock {
 
 	lock, ok := s.locks[key]
 	if !ok {
-		lock = &clientLock{}
+		pooled := s.pool.Get()
+		if pooled == nil {
+			lock = &clientLock{}
+		} else {
+			lock = pooled.(*clientLock)
+		}
 		s.locks[key] = lock
 	}
 	lock.refs++
@@ -72,7 +78,7 @@ func (s *clientLockSet) lock(key string) *clientLock {
 	return lock
 }
 
-// unlock releases a keyed lock after its final waiter leaves.
+// unlock releases a keyed lock and recycles it after its final waiter leaves.
 func (s *clientLockSet) unlock(key string, lock *clientLock) {
 	// Unlock the client before dropping its reference. A new waiter that
 	// arrives in between increments refs on this same lock, preventing it
@@ -81,10 +87,15 @@ func (s *clientLockSet) unlock(key string, lock *clientLock) {
 
 	s.mu.Lock()
 	lock.refs--
-	if lock.refs == 0 {
+	recycle := lock.refs == 0
+	if recycle {
 		delete(s.locks, key)
 	}
 	s.mu.Unlock()
+
+	if recycle {
+		s.pool.Put(lock)
+	}
 }
 
 // ruleReservation records one rule's token reservation.
@@ -120,11 +131,30 @@ func (a *rateLimitAdmission) Commit() {
 	}
 
 	a.once.Do(func() {
-		defer a.clientLocks.unlock(a.clientKey, a.clientLock)
+		// Drop all admission-owned references before recording metrics. A
+		// caller may defensively retain the admission until a long-lived
+		// backend response completes, but finalized reservations and evicted
+		// limiter entries should become collectible immediately.
+		reservations := a.reservations
+		clientLocks := a.clientLocks
+		clientKey := a.clientKey
+		clientLock := a.clientLock
+		serviceName := a.serviceName
+		a.reservations = nil
+		a.clientLocks = nil
+		a.clientKey = ""
+		a.clientLock = nil
+		a.serviceName = ""
+		a.now = time.Time{}
 
-		for _, rr := range a.reservations {
+		// Committing a reservation requires no rate.Limiter mutation. Release
+		// the exact-client lock before the Prometheus work so metrics collection
+		// cannot delay the client's next request.
+		clientLocks.unlock(clientKey, clientLock)
+
+		for _, rr := range reservations {
 			rateLimitAllowed.WithLabelValues(
-				a.serviceName, rr.cfg.PathRegexp,
+				serviceName, rr.cfg.PathRegexp,
 			).Inc()
 		}
 	})
@@ -137,10 +167,22 @@ func (a *rateLimitAdmission) Cancel() {
 	}
 
 	a.once.Do(func() {
-		defer a.clientLocks.unlock(a.clientKey, a.clientLock)
+		reservations := a.reservations
+		clientLocks := a.clientLocks
+		clientKey := a.clientKey
+		clientLock := a.clientLock
+		now := a.now
+		a.reservations = nil
+		a.clientLocks = nil
+		a.clientKey = ""
+		a.clientLock = nil
+		a.serviceName = ""
+		a.now = time.Time{}
 
-		for _, rr := range a.reservations {
-			rr.reservation.CancelAt(a.now)
+		defer clientLocks.unlock(clientKey, clientLock)
+
+		for _, rr := range reservations {
+			rr.reservation.CancelAt(now)
 		}
 	})
 }

--- a/proxy/ratelimiter.go
+++ b/proxy/ratelimiter.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lightninglabs/aperture/l402"
@@ -217,6 +218,12 @@ type RateLimiter struct {
 
 	// serviceName is used for metrics labels.
 	serviceName string
+
+	// managedCacheMetric indicates that the limiter belongs to a published
+	// service snapshot. Managed limiters contribute to a process-wide service
+	// aggregate and are explicitly removed when their snapshot is replaced.
+	managedCacheMetric bool
+	cacheMetricActive  atomic.Bool
 }
 
 // RateLimiterOption is a functional option for configuring a RateLimiter.
@@ -232,6 +239,15 @@ func WithMaxCacheSize(size int) RateLimiterOption {
 		}
 
 		rl.maxSize = size
+	}
+}
+
+// withManagedCacheMetric marks a limiter as owned by a Proxy service snapshot.
+// Direct users of NewRateLimiter retain the original last-value gauge behavior
+// because they have no lifecycle method through which to unregister it.
+func withManagedCacheMetric() RateLimiterOption {
+	return func(rl *RateLimiter) {
+		rl.managedCacheMetric = true
 	}
 }
 
@@ -275,7 +291,6 @@ func (rl *RateLimiter) Allow(r *http.Request, key string) (bool,
 // two-phase form lets callers refund capacity when a later prerequisite fails.
 func (rl *RateLimiter) reserve(r *http.Request, key string) (
 	*rateLimitAdmission, bool, time.Duration) {
-
 	path := r.URL.Path
 
 	// Find matching rules before acquiring the exact-client lock. Requests
@@ -330,8 +345,8 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 	reservations := make([]ruleReservation, 0, len(matches))
 
 	for _, match := range matches {
-		// Create a composite key for independent limiting per rule. The
-		// rule index is intentionally part of the identity because
+		// Create a composite key for independent limiting per rule.
+		// The rule index is intentionally part of the identity because
 		// multiple limits with different time horizons can legitimately
 		// use the same path pattern.
 		cacheKey := limiterKey{
@@ -358,9 +373,9 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 	for idx := range reservations {
 		rr := &reservations[idx]
 		if !rr.reservation.OK() {
-			// The request exceeds the limiter's burst. Service validation
-			// prevents this for configured rules, but keep the direct
-			// RateLimiter API fail closed.
+			// The request exceeds the limiter's burst. Service
+			// validation prevents this for configured rules, but keep
+			// the direct RateLimiter API fail closed.
 			allAllowed = false
 			rr.denied = true
 			maxWait = time.Second
@@ -390,7 +405,6 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 				recordRateLimitRuleDenied(rl.serviceName, rr)
 			}
 		}
-
 		return nil, false, maxWait
 	}
 
@@ -453,11 +467,46 @@ func (rl *RateLimiter) getOrCreateLimiter(key limiterKey,
 		rateLimitEvictions.WithLabelValues(rl.serviceName).Inc()
 	}
 
-	rateLimitCacheSize.WithLabelValues(rl.serviceName).Set(
-		float64(rl.cache.Len()),
-	)
+	rl.publishCacheSize(rl.cache.Len())
 
 	return limiter
+}
+
+// publishCacheSize records the limiter's current cache size according to its
+// ownership model.
+func (rl *RateLimiter) publishCacheSize(size int) {
+	// Preserve the original cache_size metric's last-writer behavior for API
+	// compatibility. The active_cache_size metric below provides the managed,
+	// aggregate view without allowing Proxy lifecycle operations to overwrite
+	// or delete a standalone limiter's legacy series.
+	rateLimitCacheSize.WithLabelValues(rl.serviceName).Set(float64(size))
+
+	if rl.managedCacheMetric && rl.cacheMetricActive.Load() {
+		managedRateLimitCacheMetrics.set(rl, size)
+	}
+}
+
+// activateCacheMetric starts accounting for a managed limiter after its
+// service snapshot is published.
+func (rl *RateLimiter) activateCacheMetric(size int) {
+	if !rl.managedCacheMetric {
+		return
+	}
+
+	rl.cacheMetricActive.Store(true)
+	managedRateLimitCacheMetrics.set(rl, size)
+}
+
+// removeCacheMetric removes a managed limiter from the active service
+// aggregate. It is a no-op for standalone limiters, preserving their legacy
+// metric behavior.
+func (rl *RateLimiter) removeCacheMetric() {
+	if !rl.managedCacheMetric {
+		return
+	}
+
+	rl.cacheMetricActive.Store(false)
+	managedRateLimitCacheMetrics.remove(rl)
 }
 
 // Size returns the current number of entries in the cache.

--- a/proxy/ratelimiter.go
+++ b/proxy/ratelimiter.go
@@ -219,9 +219,15 @@ type RateLimiter struct {
 // RateLimiterOption is a functional option for configuring a RateLimiter.
 type RateLimiterOption func(*RateLimiter)
 
-// WithMaxCacheSize sets the maximum cache size.
+// WithMaxCacheSize sets the maximum number of cached client-rule entries. A
+// non-positive value disables caching; matching requests then fail closed
+// because their rate-limit state cannot be retained safely.
 func WithMaxCacheSize(size int) RateLimiterOption {
 	return func(rl *RateLimiter) {
+		if size < 0 {
+			size = 0
+		}
+
 		rl.maxSize = size
 	}
 }
@@ -285,6 +291,20 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 	}
 	if len(matches) == 0 {
 		return nil, true, 0
+	}
+
+	// Every matching rule needs durable state until a later request. If one
+	// admission is larger than the explicit cache bound, admitting it would
+	// evict buckets created earlier in the same request and refresh their burst
+	// on every call. Preserve the configured maximum and fail closed instead.
+	if len(matches) > rl.maxSize {
+		for _, match := range matches {
+			rateLimitDenied.WithLabelValues(
+				rl.serviceName, match.cfg.PathRegexp,
+			).Inc()
+		}
+
+		return nil, false, time.Second
 	}
 
 	clientLock := rl.clientLocks.lock(key)

--- a/proxy/ratelimiter.go
+++ b/proxy/ratelimiter.go
@@ -34,6 +34,117 @@ type limiterEntry struct {
 	limiter *rate.Limiter
 }
 
+// clientLock serializes admissions for one exact client key. refs includes the
+// current holder and all waiters so the lock can be removed safely when the
+// last user releases it.
+type clientLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// clientLockSet provides lifecycle-bounded per-client locks. The number of
+// entries is bounded by concurrent admissions rather than historical client
+// cardinality, and unrelated clients never block each other because of a hash
+// collision.
+type clientLockSet struct {
+	mu    sync.Mutex
+	locks map[string]*clientLock
+}
+
+// lock acquires and returns the lock for key. Callers must pass the returned
+// pointer to unlock exactly once.
+func (s *clientLockSet) lock(key string) *clientLock {
+	s.mu.Lock()
+	if s.locks == nil {
+		s.locks = make(map[string]*clientLock)
+	}
+
+	lock, ok := s.locks[key]
+	if !ok {
+		lock = &clientLock{}
+		s.locks[key] = lock
+	}
+	lock.refs++
+	s.mu.Unlock()
+
+	lock.mu.Lock()
+
+	return lock
+}
+
+// unlock releases a keyed lock after its final waiter leaves.
+func (s *clientLockSet) unlock(key string, lock *clientLock) {
+	// Unlock the client before dropping its reference. A new waiter that
+	// arrives in between increments refs on this same lock, preventing it
+	// from being removed while still in use.
+	lock.mu.Unlock()
+
+	s.mu.Lock()
+	lock.refs--
+	if lock.refs == 0 {
+		delete(s.locks, key)
+	}
+	s.mu.Unlock()
+}
+
+// ruleReservation records one rule's token reservation.
+type ruleReservation struct {
+	ruleIndex   int
+	cfg         *RateLimitConfig
+	reservation *rate.Reservation
+}
+
+// matchingRule identifies one configured rule that applies to a request.
+type matchingRule struct {
+	ruleIndex int
+	cfg       *RateLimitConfig
+}
+
+// rateLimitAdmission is a successful, provisional multi-rule admission. The
+// exact client's lock remains held until Commit or Cancel, making a later
+// cancellation exact without blocking unrelated clients.
+type rateLimitAdmission struct {
+	now          time.Time
+	reservations []ruleReservation
+	clientLocks  *clientLockSet
+	clientKey    string
+	clientLock   *clientLock
+	serviceName  string
+	once         sync.Once
+}
+
+// Commit consumes the reserved tokens and records the allowed rule metrics.
+func (a *rateLimitAdmission) Commit() {
+	if a == nil {
+		return
+	}
+
+	a.once.Do(func() {
+		defer a.clientLocks.unlock(a.clientKey, a.clientLock)
+
+		for _, rr := range a.reservations {
+			rateLimitAllowed.WithLabelValues(
+				a.serviceName, rr.cfg.PathRegexp,
+			).Inc()
+		}
+	})
+}
+
+// Cancel refunds every rule reservation and releases the client lock.
+func (a *rateLimitAdmission) Cancel() {
+	if a == nil {
+		return
+	}
+
+	a.once.Do(func() {
+		defer a.clientLocks.unlock(a.clientKey, a.clientLock)
+
+		for _, rr := range a.reservations {
+			rr.reservation.CancelAt(a.now)
+		}
+	})
+}
+
 // Size implements cache.Value. Returns 1 so the LRU cache counts entries
 // rather than bytes.
 func (e *limiterEntry) Size() (uint64, error) {
@@ -44,6 +155,11 @@ func (e *limiterEntry) Size() (uint64, error) {
 type RateLimiter struct {
 	// cacheMu protects the LRU cache which is not concurrency-safe.
 	cacheMu sync.Mutex
+
+	// clientLocks serialize admission across all rules for an exact client.
+	// This makes multi-rule decisions atomic without allowing a slow
+	// provisional admission to block a hash-colliding client.
+	clientLocks clientLockSet
 
 	// configs is the list of rate limit configurations for this limiter.
 	configs []*RateLimitConfig
@@ -93,44 +209,75 @@ func NewRateLimiter(serviceName string, configs []*RateLimitConfig,
 // duration to wait if denied.
 func (rl *RateLimiter) Allow(r *http.Request, key string) (bool,
 	time.Duration) {
+	admission, allowed, retryAfter := rl.reserve(r, key)
+	if !allowed {
+		return false, retryAfter
+	}
+
+	admission.Commit()
+
+	return true, 0
+}
+
+// reserve provisionally reserves one token from every matching rule. A
+// successful admission must be finalized with Commit or Cancel. This internal
+// two-phase form lets callers refund capacity when a later prerequisite fails.
+func (rl *RateLimiter) reserve(r *http.Request, key string) (
+	*rateLimitAdmission, bool, time.Duration) {
 
 	path := r.URL.Path
 
-	// Collect all matching configs and their reservations. We need to check
-	// all rules before consuming any tokens, so that if any rule denies we
-	// can cancel all reservations.
-	type ruleReservation struct {
-		cfg         *RateLimitConfig
-		reservation *rate.Reservation
-	}
-	reservations := make([]ruleReservation, 0, len(rl.configs))
-
+	// Find matching rules before acquiring the exact-client lock. Requests
+	// that do not match any rule are unrestricted and should not contend on
+	// the global lock map or allocate a per-client lock.
+	var matches []matchingRule
 	for ruleIndex, cfg := range rl.configs {
 		if !cfg.Matches(path) {
 			continue
 		}
 
+		matches = append(matches, matchingRule{
+			ruleIndex: ruleIndex,
+			cfg:       cfg,
+		})
+	}
+	if len(matches) == 0 {
+		return nil, true, 0
+	}
+
+	clientLock := rl.clientLocks.lock(key)
+	lockTransferred := false
+	defer func() {
+		if !lockTransferred {
+			rl.clientLocks.unlock(key, clientLock)
+		}
+	}()
+
+	now := time.Now()
+
+	// Collect all matching configs and their reservations. We need to check
+	// all rules before consuming any tokens, so that if any rule denies we
+	// can cancel all reservations.
+	reservations := make([]ruleReservation, 0, len(matches))
+
+	for _, match := range matches {
 		// Create a composite key for independent limiting per rule. The
 		// rule index is intentionally part of the identity because
 		// multiple limits with different time horizons can legitimately
 		// use the same path pattern.
 		cacheKey := limiterKey{
 			clientKey: key,
-			ruleIndex: ruleIndex,
+			ruleIndex: match.ruleIndex,
 		}
 
-		limiter := rl.getOrCreateLimiter(cacheKey, cfg)
-		reservation := limiter.Reserve()
+		limiter := rl.getOrCreateLimiter(cacheKey, match.cfg)
+		reservation := limiter.ReserveN(now, 1)
 
 		reservations = append(reservations, ruleReservation{
-			cfg:         cfg,
+			ruleIndex:   match.ruleIndex,
+			cfg:         match.cfg,
 			reservation: reservation,
 		})
-	}
-
-	// If no rules matched, allow the request.
-	if len(reservations) == 0 {
-		return true, 0
 	}
 
 	// Check if all reservations can proceed immediately. If any rule
@@ -141,14 +288,15 @@ func (rl *RateLimiter) Allow(r *http.Request, key string) (bool,
 
 	for _, rr := range reservations {
 		if !rr.reservation.OK() {
-			// Rate is zero or infinity.
+			// The request exceeds the limiter's burst. Service validation
+			// prevents this for configured rules, but keep the direct
+			// RateLimiter API fail closed.
 			allAllowed = false
 			maxWait = time.Second
-
-			break
+			continue
 		}
 
-		delay := rr.reservation.Delay()
+		delay := rr.reservation.DelayFrom(now)
 		if delay > 0 {
 			allAllowed = false
 			if delay > maxWait {
@@ -160,23 +308,25 @@ func (rl *RateLimiter) Allow(r *http.Request, key string) (bool,
 	// If any rule denied, cancel all reservations and return denied.
 	if !allAllowed {
 		for _, rr := range reservations {
-			rr.reservation.Cancel()
+			rr.reservation.CancelAt(now)
 			rateLimitDenied.WithLabelValues(
 				rl.serviceName, rr.cfg.PathRegexp,
 			).Inc()
 		}
 
-		return false, maxWait
+		return nil, false, maxWait
 	}
 
-	// All rules allowed - tokens are consumed, record metrics.
-	for _, rr := range reservations {
-		rateLimitAllowed.WithLabelValues(
-			rl.serviceName, rr.cfg.PathRegexp,
-		).Inc()
-	}
+	lockTransferred = true
 
-	return true, 0
+	return &rateLimitAdmission{
+		now:          now,
+		reservations: reservations,
+		clientLocks:  &rl.clientLocks,
+		clientKey:    key,
+		clientLock:   clientLock,
+		serviceName:  rl.serviceName,
+	}, true, 0
 }
 
 // getOrCreateLimiter retrieves an existing limiter or creates a new one.

--- a/proxy/ratelimiter.go
+++ b/proxy/ratelimiter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -103,6 +104,7 @@ type ruleReservation struct {
 	ruleIndex   int
 	cfg         *RateLimitConfig
 	reservation *rate.Reservation
+	denied      bool
 }
 
 // matchingRule identifies one configured rule that applies to a request.
@@ -156,6 +158,7 @@ func (a *rateLimitAdmission) Commit() {
 			rateLimitAllowed.WithLabelValues(
 				serviceName, rr.cfg.PathRegexp,
 			).Inc()
+			recordRateLimitRuleAllowed(serviceName, rr)
 		}
 	})
 }
@@ -302,6 +305,10 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 			rateLimitDenied.WithLabelValues(
 				rl.serviceName, match.cfg.PathRegexp,
 			).Inc()
+			recordRateLimitRuleDenied(rl.serviceName, ruleReservation{
+				ruleIndex: match.ruleIndex,
+				cfg:       match.cfg,
+			})
 		}
 
 		return nil, false, time.Second
@@ -348,12 +355,14 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 	var maxWait time.Duration
 	allAllowed := true
 
-	for _, rr := range reservations {
+	for idx := range reservations {
+		rr := &reservations[idx]
 		if !rr.reservation.OK() {
 			// The request exceeds the limiter's burst. Service validation
 			// prevents this for configured rules, but keep the direct
 			// RateLimiter API fail closed.
 			allAllowed = false
+			rr.denied = true
 			maxWait = time.Second
 			continue
 		}
@@ -361,6 +370,7 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 		delay := rr.reservation.DelayFrom(now)
 		if delay > 0 {
 			allAllowed = false
+			rr.denied = true
 			if delay > maxWait {
 				maxWait = delay
 			}
@@ -371,9 +381,14 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 	if !allAllowed {
 		for _, rr := range reservations {
 			rr.reservation.CancelAt(now)
+			// Preserve the original path-aggregated metric semantics:
+			// every matching rule is counted when the request is denied.
 			rateLimitDenied.WithLabelValues(
 				rl.serviceName, rr.cfg.PathRegexp,
 			).Inc()
+			if rr.denied {
+				recordRateLimitRuleDenied(rl.serviceName, rr)
+			}
 		}
 
 		return nil, false, maxWait
@@ -389,6 +404,26 @@ func (rl *RateLimiter) reserve(r *http.Request, key string) (
 		clientLock:   clientLock,
 		serviceName:  rl.serviceName,
 	}, true, 0
+}
+
+// recordRateLimitRuleAllowed records a rule-specific allowed evaluation while
+// retaining the original path-aggregated metric for compatibility.
+func recordRateLimitRuleAllowed(serviceName string, rr ruleReservation) {
+	rateLimitRuleAllowed.WithLabelValues(
+		serviceName, rr.cfg.PathRegexp, strconv.Itoa(rr.cfg.Requests),
+		rr.cfg.Per.String(),
+		strconv.Itoa(rr.cfg.EffectiveBurst()),
+	).Inc()
+}
+
+// recordRateLimitRuleDenied records a rule-specific denied evaluation while
+// retaining the original path-aggregated metric for compatibility.
+func recordRateLimitRuleDenied(serviceName string, rr ruleReservation) {
+	rateLimitRuleDenied.WithLabelValues(
+		serviceName, rr.cfg.PathRegexp, strconv.Itoa(rr.cfg.Requests),
+		rr.cfg.Per.String(),
+		strconv.Itoa(rr.cfg.EffectiveBurst()),
+	).Inc()
 }
 
 // getOrCreateLimiter retrieves an existing limiter or creates a new one.

--- a/proxy/ratelimiter_proxy_test.go
+++ b/proxy/ratelimiter_proxy_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/aperture/auth"
+	"github.com/lightninglabs/aperture/pricer"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRateLimiterZeroPrice makes sure an unauthenticated request that is free
+// according to the pricer is still rate limited by IP.
+func TestRateLimiterZeroPrice(t *testing.T) {
+	p, service, backendCalls := newRateLimitTestProxy(
+		t, auth.Level("on"), 1, time.Hour,
+	)
+	service.pricer = pricer.NewDefaultPricer(0)
+
+	serveRateLimitRequest(t, p, http.StatusOK)
+	serveRateLimitRequest(t, p, http.StatusTooManyRequests)
+	require.Equal(t, int32(1), backendCalls.Load())
+}
+
+// newRateLimitTestProxy creates a proxy with a one-token burst and a backend
+// that records how many requests were forwarded.
+func newRateLimitTestProxy(t *testing.T, authLevel auth.Level, requests int,
+	per time.Duration) (*Proxy, *Service, *atomic.Int32) {
+
+	t.Helper()
+
+	var backendCalls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request) {
+
+		backendCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	service := &Service{
+		Name:       t.Name(),
+		Address:    backendURL.Host,
+		Protocol:   backendURL.Scheme,
+		HostRegexp: ".*",
+		PathRegexp: "^/limited$",
+		Auth:       authLevel,
+		RateLimits: []*RateLimitConfig{{
+			Requests: requests,
+			Per:      per,
+			Burst:    1,
+		}},
+	}
+	p, err := New(
+		auth.NewMockAuthenticator(), []*Service{service}, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+
+	return p, service, &backendCalls
+}
+
+// serveRateLimitRequest sends one request directly through the proxy.
+func serveRateLimitRequest(t *testing.T, p *Proxy, expectedStatus int) {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", "http://example.com/limited", nil)
+	recorder := httptest.NewRecorder()
+	p.ServeHTTP(recorder, req)
+	require.Equal(t, expectedStatus, recorder.Code)
+}

--- a/proxy/ratelimiter_proxy_test.go
+++ b/proxy/ratelimiter_proxy_test.go
@@ -122,7 +122,10 @@ func newRateLimitTestProxy(t *testing.T, authLevel auth.Level, requests int,
 		require.NoError(t, p.Close())
 	})
 
-	return p, service, &backendCalls
+	// UpdateServices publishes an immutable prepared snapshot, so return the
+	// service owned by the proxy when a test needs to replace an internal
+	// dependency such as the pricer or freebie store.
+	return p, p.services[0], &backendCalls
 }
 
 // serveRateLimitRequest sends one request directly through the proxy.

--- a/proxy/ratelimiter_proxy_test.go
+++ b/proxy/ratelimiter_proxy_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,6 +26,60 @@ func TestRateLimiterZeroPrice(t *testing.T) {
 	serveRateLimitRequest(t, p, http.StatusOK)
 	serveRateLimitRequest(t, p, http.StatusTooManyRequests)
 	require.Equal(t, int32(1), backendCalls.Load())
+}
+
+// TestRateLimiterDoesNotConsumeFreebie makes sure a rate limited request does
+// not consume one of the client's free requests.
+func TestRateLimiterDoesNotConsumeFreebie(t *testing.T) {
+	p, service, backendCalls := newRateLimitTestProxy(
+		t, auth.Level("freebie 2"), 1, time.Hour,
+	)
+
+	serveRateLimitRequest(t, p, http.StatusOK)
+	serveRateLimitRequest(t, p, http.StatusTooManyRequests)
+
+	// Replace the exhausted test bucket rather than depending on wall-clock
+	// refill timing. The next request should still have the second freebie
+	// available because the denied request was not tallied.
+	service.rateLimiter = NewRateLimiter(
+		service.Name, service.RateLimits,
+	)
+	serveRateLimitRequest(t, p, http.StatusOK)
+	serveRateLimitRequest(t, p, http.StatusPaymentRequired)
+	require.Equal(t, int32(2), backendCalls.Load())
+}
+
+// TestRateLimiterRefundsFreebieFailure makes sure an internal freebie store
+// failure does not consume rate-limit capacity for a request that is never
+// forwarded.
+func TestRateLimiterRefundsFreebieFailure(t *testing.T) {
+	p, service, backendCalls := newRateLimitTestProxy(
+		t, auth.Level("freebie 2"), 1, time.Hour,
+	)
+	service.freebieDB = &failOnceFreebieDB{}
+
+	serveRateLimitRequest(t, p, http.StatusInternalServerError)
+	serveRateLimitRequest(t, p, http.StatusOK)
+	require.Equal(t, int32(1), backendCalls.Load())
+}
+
+// failOnceFreebieDB fails its first tally and accepts subsequent tallies.
+type failOnceFreebieDB struct {
+	failed atomic.Bool
+}
+
+func (f *failOnceFreebieDB) CanPass(*http.Request, net.IP) (bool, error) {
+	return true, nil
+}
+
+func (f *failOnceFreebieDB) TallyFreebie(*http.Request,
+	net.IP) (bool, error) {
+
+	if f.failed.CompareAndSwap(false, true) {
+		return false, errors.New("injected freebie tally failure")
+	}
+
+	return true, nil
 }
 
 // newRateLimitTestProxy creates a proxy with a one-token burst and a backend

--- a/proxy/ratelimiter_proxy_test.go
+++ b/proxy/ratelimiter_proxy_test.go
@@ -41,9 +41,11 @@ func TestRateLimiterDoesNotConsumeFreebie(t *testing.T) {
 	// Replace the exhausted test bucket rather than depending on wall-clock
 	// refill timing. The next request should still have the second freebie
 	// available because the denied request was not tallied.
+	service.rateLimiter.removeCacheMetric()
 	service.rateLimiter = NewRateLimiter(
-		service.Name, service.RateLimits,
+		service.Name, service.RateLimits, withManagedCacheMetric(),
 	)
+	service.rateLimiter.activateCacheMetric(0)
 	serveRateLimitRequest(t, p, http.StatusOK)
 	serveRateLimitRequest(t, p, http.StatusPaymentRequired)
 	require.Equal(t, int32(2), backendCalls.Load())

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -374,6 +375,56 @@ func TestRateLimiterProvisionalAdmissionsSerializeSameClient(t *testing.T) {
 	}
 }
 
+// TestRateLimiterAdmissionDropsReferences makes sure finalization releases the
+// exact-client lock and stops retaining reservations even if a caller keeps the
+// admission object alive.
+func TestRateLimiterAdmissionDropsReferences(t *testing.T) {
+	for _, commit := range []bool{true, false} {
+		name := "cancel"
+		if commit {
+			name = "commit"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			cfg := &RateLimitConfig{
+				Requests: 1,
+				Per:      time.Hour,
+				Burst:    1,
+			}
+			rl := NewRateLimiter(t.Name(), []*RateLimitConfig{cfg})
+			req := httptest.NewRequest("GET", "/limited", nil)
+
+			admission, allowed, _ := rl.reserve(req, "test-key")
+			require.True(t, allowed)
+			require.NotEmpty(t, admission.reservations)
+			require.NotNil(t, admission.clientLocks)
+			require.NotNil(t, admission.clientLock)
+			require.Equal(t, "test-key", admission.clientKey)
+
+			if commit {
+				admission.Commit()
+			} else {
+				admission.Cancel()
+			}
+
+			require.Nil(t, admission.reservations)
+			require.Nil(t, admission.clientLocks)
+			require.Nil(t, admission.clientLock)
+			require.Empty(t, admission.clientKey)
+			require.Empty(t, admission.serviceName)
+			require.True(t, admission.now.IsZero())
+
+			// Finalization remains idempotent in either order.
+			admission.Commit()
+			admission.Cancel()
+
+			rl.clientLocks.mu.Lock()
+			require.Empty(t, rl.clientLocks.locks)
+			rl.clientLocks.mu.Unlock()
+		})
+	}
+}
+
 // TestRateLimiterAdmissionConcurrentFinalization races Commit and Cancel to
 // verify that exactly one terminal action takes effect and the client lock is
 // released once.
@@ -420,12 +471,55 @@ func TestRateLimiterAdmissionConcurrentFinalization(t *testing.T) {
 	)
 	commitWon := allowedAfter == allowedBefore+1
 	require.True(t, commitWon || allowedAfter == allowedBefore)
+	require.Nil(t, admission.reservations)
+	require.Nil(t, admission.clientLocks)
+	require.Nil(t, admission.clientLock)
 
 	nextAllowed, _ := rl.Allow(req, "same-client")
 	require.Equal(t, !commitWon, nextAllowed)
 	rl.clientLocks.mu.Lock()
 	require.Empty(t, rl.clientLocks.locks)
 	rl.clientLocks.mu.Unlock()
+}
+
+// TestClientLockSetHighChurn exercises pooled lock reuse while many keys and
+// waiters contend. At most one goroutine may hold a given key at a time, and no
+// historical key may remain after the final release.
+func TestClientLockSetHighChurn(t *testing.T) {
+	const (
+		keyCount = 8
+		workers  = 32
+		loops    = 500
+	)
+
+	var locks clientLockSet
+	active := make([]atomic.Int32, keyCount)
+	var violated atomic.Bool
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+
+			for iteration := 0; iteration < loops; iteration++ {
+				keyIndex := (worker + iteration) % keyCount
+				key := fmt.Sprintf("key-%d", keyIndex)
+				lock := locks.lock(key)
+				if active[keyIndex].Add(1) != 1 {
+					violated.Store(true)
+				}
+				runtime.Gosched()
+				active[keyIndex].Add(-1)
+				locks.unlock(key, lock)
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	require.False(t, violated.Load())
+	locks.mu.Lock()
+	require.Empty(t, locks.locks)
+	locks.mu.Unlock()
 }
 
 // legacyClientLockShard computes the shard used by the former lock scheme.

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -732,6 +732,82 @@ func TestRateLimiterDeniedMetrics(t *testing.T) {
 	)
 }
 
+// prometheusCounterValue returns the value of a counter with an exact label
+// set, or zero if the labeled metric has not been collected yet.
+func prometheusCounterValue(t *testing.T, name string,
+	wantLabels map[string]string) float64 {
+
+	t.Helper()
+
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, family := range metricFamilies {
+		if family.GetName() != name {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if !mapsEqual(labels, wantLabels) {
+				continue
+			}
+
+			return metric.GetCounter().GetValue()
+		}
+	}
+
+	return 0
+}
+
+// prometheusGaugeValue returns the value of a gauge with an exact label set.
+func prometheusGaugeValue(t *testing.T, name string,
+	wantLabels map[string]string) (float64, bool) {
+
+	t.Helper()
+
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, family := range metricFamilies {
+		if family.GetName() != name {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if !mapsEqual(labels, wantLabels) {
+				continue
+			}
+
+			return metric.GetGauge().GetValue(), true
+		}
+	}
+
+	return 0, false
+}
+
+// mapsEqual returns true if two string maps contain identical entries.
+func mapsEqual(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for key, value := range left {
+		if right[key] != value {
+			return false
+		}
+	}
+
+	return true
+}
+
 // TestRateLimiterPerKeyIsolation tests that different keys have independent
 // rate limits.
 func TestRateLimiterPerKeyIsolation(t *testing.T) {
@@ -997,49 +1073,4 @@ func TestRateLimiterTokenRefill(t *testing.T) {
 	// Should have a token now.
 	allowed, _ = rl.Allow(req, "test-key")
 	require.True(t, allowed)
-}
-
-// prometheusCounterValue returns the value of a counter with an exact label
-// set, or zero if the labeled metric has not been collected yet.
-func prometheusCounterValue(t *testing.T, name string,
-	wantLabels map[string]string) float64 {
-
-	t.Helper()
-
-	metricFamilies, err := prometheus.DefaultGatherer.Gather()
-	require.NoError(t, err)
-
-	for _, family := range metricFamilies {
-		if family.GetName() != name {
-			continue
-		}
-
-		for _, metric := range family.GetMetric() {
-			labels := make(map[string]string, len(metric.GetLabel()))
-			for _, label := range metric.GetLabel() {
-				labels[label.GetName()] = label.GetValue()
-			}
-			if !mapsEqual(labels, wantLabels) {
-				continue
-			}
-
-			return metric.GetCounter().GetValue()
-		}
-	}
-
-	return 0
-}
-
-func mapsEqual(left, right map[string]string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-
-	for key, value := range left {
-		if right[key] != value {
-			return false
-		}
-	}
-
-	return true
 }

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -92,6 +92,69 @@ func TestRateLimiterLRUEviction(t *testing.T) {
 	require.Equal(t, 5, rl.Size())
 }
 
+// TestRateLimiterUndersizedCacheFailsClosed makes sure an admission larger than
+// the explicit cache bound cannot refresh its burst by evicting its own rules.
+func TestRateLimiterUndersizedCacheFailsClosed(t *testing.T) {
+	first := &RateLimitConfig{
+		PathRegexp: "^/same$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      1,
+	}
+	second := &RateLimitConfig{
+		PathRegexp: "^/same$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      1,
+	}
+	first.compiledPathRegexp = regexp.MustCompile(first.PathRegexp)
+	second.compiledPathRegexp = regexp.MustCompile(second.PathRegexp)
+
+	rl := NewRateLimiter(
+		t.Name(), []*RateLimitConfig{first, second},
+		WithMaxCacheSize(1),
+	)
+	require.Equal(t, 1, rl.maxSize)
+	req := httptest.NewRequest("GET", "/same", nil)
+
+	allowed, retryAfter := rl.Allow(req, "test-key")
+	require.False(t, allowed)
+	require.Equal(t, time.Second, retryAfter)
+	require.Zero(t, rl.Size())
+
+	// The decision remains fail-closed rather than receiving a fresh burst on
+	// every subsequent request.
+	allowed, _ = rl.Allow(req, "test-key")
+	require.False(t, allowed)
+}
+
+// TestRateLimiterCacheSizeOptions makes sure the public option remains an
+// actual upper bound, including its zero-cache behavior.
+func TestRateLimiterCacheSizeOptions(t *testing.T) {
+	for _, size := range []int{0, -1} {
+		cfg := &RateLimitConfig{
+			Requests: 1,
+			Per:      time.Hour,
+			Burst:    1,
+		}
+		rl := NewRateLimiter(
+			t.Name(), []*RateLimitConfig{cfg}, WithMaxCacheSize(size),
+		)
+		require.Zero(t, rl.maxSize)
+
+		req := httptest.NewRequest("GET", "/limited", nil)
+		allowed, _ := rl.Allow(req, "test-key")
+		require.False(t, allowed)
+		require.Zero(t, rl.Size())
+	}
+
+	configs := []*RateLimitConfig{{}, {}, {}}
+	rl := NewRateLimiter(
+		t.Name(), configs, WithMaxCacheSize(len(configs)-1),
+	)
+	require.Equal(t, len(configs)-1, rl.maxSize)
+}
+
 // TestRateLimiterPathMatching tests that different path patterns have
 // independent limits.
 func TestRateLimiterPathMatching(t *testing.T) {

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -875,6 +875,18 @@ func TestExtractRateLimitKeyUnauthenticatedIgnoresL402(t *testing.T) {
 	require.Equal(t, "ip:192.168.1.0", key)
 }
 
+// TestExtractRateLimitKeyAuthenticated makes sure a validated L402 request is
+// keyed by its token ID instead of the peer IP.
+func TestExtractRateLimitKeyAuthenticated(t *testing.T) {
+	mac, tokenID := newTestMacaroon(t)
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", authHeaderForMacaroon(t, mac))
+	ip := net.ParseIP("192.168.1.100")
+
+	key := ExtractRateLimitKey(req, ip, true)
+	require.Equal(t, "token:"+tokenID, key)
+}
+
 // TestRateLimitConfigRate tests the Rate() calculation.
 func TestRateLimitConfigRate(t *testing.T) {
 	tests := []struct {

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -623,12 +623,113 @@ func TestRateLimiterDuplicatePatternsIndependent(t *testing.T) {
 		t.Name(), []*RateLimitConfig{lenient, strict},
 	)
 	req := httptest.NewRequest("GET", "/same", nil)
+	strictLabels := map[string]string{
+		"service":      t.Name(),
+		"path_pattern": strict.PathRegexp,
+		"requests":     "1",
+		"per":          time.Hour.String(),
+		"burst":        "1",
+	}
+	strictDeniedBefore := prometheusCounterValue(
+		t, "aperture_ratelimit_rule_denied_total", strictLabels,
+	)
 
 	allowed, _ := rl.Allow(req, "test-key")
 	require.True(t, allowed)
 	allowed, _ = rl.Allow(req, "test-key")
 	require.False(t, allowed)
 	require.Equal(t, 2, rl.Size())
+
+	require.Equal(
+		t, strictDeniedBefore+1, prometheusCounterValue(
+			t, "aperture_ratelimit_rule_denied_total", strictLabels,
+		),
+	)
+}
+
+// TestRateLimiterDeniedMetrics makes sure the legacy path metric retains its
+// original all-matching-rules semantics, while the rule-specific metric only
+// attributes the denial to the rule that actually rejected the request.
+func TestRateLimiterDeniedMetrics(t *testing.T) {
+	global := &RateLimitConfig{
+		Requests: 1,
+		Per:      time.Hour,
+		Burst:    2,
+	}
+	specific := &RateLimitConfig{
+		PathRegexp: "^/metric-expensive$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      1,
+	}
+	specific.compiledPathRegexp = regexp.MustCompile(specific.PathRegexp)
+
+	rl := NewRateLimiter(
+		t.Name(), []*RateLimitConfig{global, specific},
+	)
+	globalLabels := map[string]string{
+		"service":      t.Name(),
+		"path_pattern": "",
+	}
+	specificLabels := map[string]string{
+		"service":      t.Name(),
+		"path_pattern": specific.PathRegexp,
+	}
+	globalBefore := prometheusCounterValue(
+		t, "aperture_ratelimit_denied_total", globalLabels,
+	)
+	specificBefore := prometheusCounterValue(
+		t, "aperture_ratelimit_denied_total", specificLabels,
+	)
+	ruleGlobalLabels := map[string]string{
+		"service":      t.Name(),
+		"path_pattern": "",
+		"requests":     "1",
+		"per":          time.Hour.String(),
+		"burst":        "2",
+	}
+	ruleSpecificLabels := map[string]string{
+		"service":      t.Name(),
+		"path_pattern": specific.PathRegexp,
+		"requests":     "1",
+		"per":          time.Hour.String(),
+		"burst":        "1",
+	}
+	ruleGlobalBefore := prometheusCounterValue(
+		t, "aperture_ratelimit_rule_denied_total", ruleGlobalLabels,
+	)
+	ruleSpecificBefore := prometheusCounterValue(
+		t, "aperture_ratelimit_rule_denied_total", ruleSpecificLabels,
+	)
+	req := httptest.NewRequest("GET", "/metric-expensive", nil)
+
+	allowed, _ := rl.Allow(req, "test-key")
+	require.True(t, allowed)
+	allowed, _ = rl.Allow(req, "test-key")
+	require.False(t, allowed)
+
+	require.Equal(
+		t, globalBefore+1, prometheusCounterValue(
+			t, "aperture_ratelimit_denied_total", globalLabels,
+		),
+	)
+	require.Equal(
+		t, specificBefore+1, prometheusCounterValue(
+			t, "aperture_ratelimit_denied_total", specificLabels,
+		),
+	)
+	require.Equal(
+		t, ruleGlobalBefore, prometheusCounterValue(
+			t, "aperture_ratelimit_rule_denied_total",
+			ruleGlobalLabels,
+		),
+	)
+	require.Equal(
+		t, ruleSpecificBefore+1, prometheusCounterValue(
+			t, "aperture_ratelimit_rule_denied_total",
+			ruleSpecificLabels,
+		),
+	)
 }
 
 // TestRateLimiterPerKeyIsolation tests that different keys have independent

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -168,6 +168,36 @@ func TestRateLimiterMultipleRulesAllMustPass(t *testing.T) {
 	require.False(t, allowed, "should be denied by /expensive rule")
 }
 
+// TestRateLimiterDuplicatePatternsIndependent makes sure rules with identical
+// path patterns retain their own rates and bursts.
+func TestRateLimiterDuplicatePatternsIndependent(t *testing.T) {
+	lenient := &RateLimitConfig{
+		PathRegexp: "^/same$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      10,
+	}
+	strict := &RateLimitConfig{
+		PathRegexp: "^/same$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      1,
+	}
+	lenient.compiledPathRegexp = regexp.MustCompile(lenient.PathRegexp)
+	strict.compiledPathRegexp = regexp.MustCompile(strict.PathRegexp)
+
+	rl := NewRateLimiter(
+		t.Name(), []*RateLimitConfig{lenient, strict},
+	)
+	req := httptest.NewRequest("GET", "/same", nil)
+
+	allowed, _ := rl.Allow(req, "test-key")
+	require.True(t, allowed)
+	allowed, _ = rl.Allow(req, "test-key")
+	require.False(t, allowed)
+	require.Equal(t, 2, rl.Size())
+}
+
 // TestRateLimiterPerKeyIsolation tests that different keys have independent
 // rate limits.
 func TestRateLimiterPerKeyIsolation(t *testing.T) {

--- a/proxy/ratelimiter_test.go
+++ b/proxy/ratelimiter_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,9 +56,15 @@ func TestRateLimiterNoMatchingRules(t *testing.T) {
 	// Request to non-matching path should always be allowed.
 	for i := 0; i < 100; i++ {
 		req := httptest.NewRequest("GET", "/other/path", nil)
-		allowed, _ := rl.Allow(req, "test-key")
+		allowed, _ := rl.Allow(req, fmt.Sprintf("test-key-%d", i))
 		require.True(t, allowed, "non-matching request should be allowed")
 	}
+
+	// Non-matching traffic must not allocate cache entries or keyed locks.
+	require.Zero(t, rl.Size())
+	rl.clientLocks.mu.Lock()
+	require.Nil(t, rl.clientLocks.locks)
+	rl.clientLocks.mu.Unlock()
 }
 
 // TestRateLimiterLRUEviction tests that the LRU cache evicts old entries.
@@ -166,6 +175,273 @@ func TestRateLimiterMultipleRulesAllMustPass(t *testing.T) {
 	req := httptest.NewRequest("GET", "/expensive", nil)
 	allowed, _ := rl.Allow(req, "test-key")
 	require.False(t, allowed, "should be denied by /expensive rule")
+}
+
+// TestRateLimiterDeniedRuleDoesNotConsumeAllowedRule makes sure a request
+// denied by one rule does not consume capacity from another matching rule.
+func TestRateLimiterDeniedRuleDoesNotConsumeAllowedRule(t *testing.T) {
+	global := &RateLimitConfig{
+		Requests: 1,
+		Per:      time.Hour,
+		Burst:    2,
+	}
+	specific := &RateLimitConfig{
+		PathRegexp: "^/expensive$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      1,
+	}
+	specific.compiledPathRegexp = regexp.MustCompile(specific.PathRegexp)
+
+	rl := NewRateLimiter(
+		t.Name(), []*RateLimitConfig{global, specific},
+	)
+	expensive := httptest.NewRequest("GET", "/expensive", nil)
+	other := httptest.NewRequest("GET", "/other", nil)
+
+	allowed, _ := rl.Allow(expensive, "test-key")
+	require.True(t, allowed)
+
+	allowed, _ = rl.Allow(expensive, "test-key")
+	require.False(t, allowed)
+
+	// The rejected expensive request must not spend the second global
+	// token, so an unrelated path still has capacity.
+	allowed, _ = rl.Allow(other, "test-key")
+	require.True(t, allowed)
+}
+
+// TestRateLimiterConcurrentMultipleRulesAtomic makes sure concurrent requests
+// for one client cannot partially consume a set of matching rules.
+func TestRateLimiterConcurrentMultipleRulesAtomic(t *testing.T) {
+	global := &RateLimitConfig{
+		Requests: 1,
+		Per:      time.Hour,
+		Burst:    20,
+	}
+	specific := &RateLimitConfig{
+		PathRegexp: "^/concurrent-expensive$",
+		Requests:   1,
+		Per:        time.Hour,
+		Burst:      1,
+	}
+	specific.compiledPathRegexp = regexp.MustCompile(specific.PathRegexp)
+
+	rl := NewRateLimiter(
+		t.Name(), []*RateLimitConfig{global, specific},
+	)
+	var allowedCount atomic.Int32
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			req := httptest.NewRequest(
+				"GET", "/concurrent-expensive", nil,
+			)
+			allowed, _ := rl.Allow(req, "test-key")
+			if allowed {
+				allowedCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), allowedCount.Load())
+
+	// Only the one successful request should have consumed global
+	// capacity, leaving 19 tokens for paths that do not match the strict
+	// rule.
+	other := httptest.NewRequest("GET", "/other", nil)
+	for range 19 {
+		allowed, _ := rl.Allow(other, "test-key")
+		require.True(t, allowed)
+	}
+	allowed, _ := rl.Allow(other, "test-key")
+	require.False(t, allowed)
+}
+
+// TestRateLimiterProvisionalAdmissionsAreIsolatedByClient makes sure an
+// admission held open for one client does not block an unrelated client. The
+// keys deliberately collide under the former 256-shard FNV lock scheme.
+func TestRateLimiterProvisionalAdmissionsAreIsolatedByClient(t *testing.T) {
+	cfg := &RateLimitConfig{
+		Requests: 10,
+		Per:      time.Hour,
+		Burst:    10,
+	}
+	rl := NewRateLimiter(t.Name(), []*RateLimitConfig{cfg})
+	req := httptest.NewRequest("GET", "/limited", nil)
+
+	firstKey := "client-a"
+	firstShard := legacyClientLockShard(firstKey)
+	var collidingKey string
+	for i := 0; ; i++ {
+		candidate := fmt.Sprintf("client-%d", i)
+		if candidate != firstKey &&
+			legacyClientLockShard(candidate) == firstShard {
+
+			collidingKey = candidate
+			break
+		}
+	}
+
+	admission, allowed, _ := rl.reserve(req, firstKey)
+	require.True(t, allowed)
+	defer admission.Cancel()
+
+	result := make(chan bool, 1)
+	go func() {
+		allowed, _ := rl.Allow(req, collidingKey)
+		result <- allowed
+	}()
+
+	select {
+	case allowed := <-result:
+		require.True(t, allowed)
+
+	case <-time.After(time.Second):
+		t.Fatal("hash-colliding client blocked by provisional admission")
+	}
+
+	admission.Cancel()
+	rl.clientLocks.mu.Lock()
+	remainingLocks := len(rl.clientLocks.locks)
+	rl.clientLocks.mu.Unlock()
+	require.Zero(t, remainingLocks)
+}
+
+// TestRateLimiterProvisionalAdmissionsSerializeSameClient verifies that a
+// provisional admission remains the exact ordering boundary for later
+// requests using the same client key.
+func TestRateLimiterProvisionalAdmissionsSerializeSameClient(t *testing.T) {
+	for _, commit := range []bool{false, true} {
+		name := "cancel"
+		if commit {
+			name = "commit"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			cfg := &RateLimitConfig{
+				Requests: 1,
+				Per:      time.Hour,
+				Burst:    1,
+			}
+			rl := NewRateLimiter(t.Name(), []*RateLimitConfig{cfg})
+			req := httptest.NewRequest("GET", "/limited", nil)
+
+			first, allowed, _ := rl.reserve(req, "same-client")
+			require.True(t, allowed)
+			defer first.Cancel()
+
+			result := make(chan bool, 1)
+			go func() {
+				allowed, _ := rl.Allow(req, "same-client")
+				result <- allowed
+			}()
+
+			// Wait until the second admission has registered as a waiter,
+			// then prove it cannot pass the first admission out of order.
+			require.Eventually(t, func() bool {
+				rl.clientLocks.mu.Lock()
+				defer rl.clientLocks.mu.Unlock()
+
+				lock := rl.clientLocks.locks["same-client"]
+				return lock != nil && lock.refs == 2
+			}, time.Second, time.Millisecond)
+			select {
+			case <-result:
+				t.Fatal("same-client admission completed out of order")
+			default:
+			}
+
+			if commit {
+				first.Commit()
+			} else {
+				first.Cancel()
+			}
+
+			select {
+			case secondAllowed := <-result:
+				require.Equal(t, !commit, secondAllowed)
+			case <-time.After(time.Second):
+				t.Fatal("same-client admission did not resume")
+			}
+			rl.clientLocks.mu.Lock()
+			require.Empty(t, rl.clientLocks.locks)
+			rl.clientLocks.mu.Unlock()
+		})
+	}
+}
+
+// TestRateLimiterAdmissionConcurrentFinalization races Commit and Cancel to
+// verify that exactly one terminal action takes effect and the client lock is
+// released once.
+func TestRateLimiterAdmissionConcurrentFinalization(t *testing.T) {
+	cfg := &RateLimitConfig{
+		Requests: 1,
+		Per:      time.Hour,
+		Burst:    1,
+	}
+	rl := NewRateLimiter(t.Name(), []*RateLimitConfig{cfg})
+	req := httptest.NewRequest("GET", "/limited", nil)
+	labels := map[string]string{
+		"service":      t.Name(),
+		"path_pattern": "",
+	}
+	allowedBefore := prometheusCounterValue(
+		t, "aperture_ratelimit_allowed_total", labels,
+	)
+
+	admission, allowed, _ := rl.reserve(req, "same-client")
+	require.True(t, allowed)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(commit bool) {
+			defer wg.Done()
+			<-start
+
+			if commit {
+				admission.Commit()
+				return
+			}
+
+			admission.Cancel()
+		}(i%2 == 0)
+	}
+	close(start)
+	wg.Wait()
+
+	allowedAfter := prometheusCounterValue(
+		t, "aperture_ratelimit_allowed_total", labels,
+	)
+	commitWon := allowedAfter == allowedBefore+1
+	require.True(t, commitWon || allowedAfter == allowedBefore)
+
+	nextAllowed, _ := rl.Allow(req, "same-client")
+	require.Equal(t, !commitWon, nextAllowed)
+	rl.clientLocks.mu.Lock()
+	require.Empty(t, rl.clientLocks.locks)
+	rl.clientLocks.mu.Unlock()
+}
+
+// legacyClientLockShard computes the shard used by the former lock scheme.
+func legacyClientLockShard(key string) uint32 {
+	const (
+		offset32 = uint32(2166136261)
+		prime32  = uint32(16777619)
+	)
+
+	hash := offset32
+	for idx := 0; idx < len(key); idx++ {
+		hash ^= uint32(key[idx])
+		hash *= prime32
+	}
+
+	return hash % 256
 }
 
 // TestRateLimiterDuplicatePatternsIndependent makes sure rules with identical
@@ -463,4 +739,49 @@ func TestRateLimiterTokenRefill(t *testing.T) {
 	// Should have a token now.
 	allowed, _ = rl.Allow(req, "test-key")
 	require.True(t, allowed)
+}
+
+// prometheusCounterValue returns the value of a counter with an exact label
+// set, or zero if the labeled metric has not been collected yet.
+func prometheusCounterValue(t *testing.T, name string,
+	wantLabels map[string]string) float64 {
+
+	t.Helper()
+
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, family := range metricFamilies {
+		if family.GetName() != name {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if !mapsEqual(labels, wantLabels) {
+				continue
+			}
+
+			return metric.GetCounter().GetValue()
+		}
+	}
+
+	return 0
+}
+
+func mapsEqual(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for key, value := range left {
+		if right[key] != value {
+			return false
+		}
+	}
+
+	return true
 }

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -373,9 +373,12 @@ func prepareServices(services []*Service) error {
 						"negative", service.Name, i)
 				}
 
-				// Compile path regex if provided.
+				// Compile the path regex, assigning only after successful
+				// compilation. An empty expression intentionally stores nil
+				// and matches all paths.
+				var compiled *regexp.Regexp
 				if rl.PathRegexp != "" {
-					compiled, err := regexp.Compile(
+					compiled, err = regexp.Compile(
 						rl.PathRegexp,
 					)
 					if err != nil {
@@ -385,8 +388,8 @@ func prepareServices(services []*Service) error {
 							"%w", service.Name, i,
 							err)
 					}
-					rl.compiledPathRegexp = compiled
 				}
+				rl.compiledPathRegexp = compiled
 			}
 
 			// Create the rate limiter for this service.
@@ -397,6 +400,10 @@ func prepareServices(services []*Service) error {
 			log.Infof("Initialized rate limiter for service %s "+
 				"with %d rules", service.Name,
 				len(service.RateLimits))
+		} else {
+			// A Service can be reused in UpdateServices. Explicitly clear
+			// a previously initialized limiter when its rules are removed.
+			service.rateLimiter = nil
 		}
 
 		// Validate the dynamic pricer configuration, which also catches

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -350,6 +350,12 @@ func prepareServices(services []*Service) error {
 		// Validate and compile rate limit configurations.
 		if len(service.RateLimits) > 0 {
 			for i, rl := range service.RateLimits {
+				if rl == nil {
+					return fmt.Errorf("service %s rate "+
+						"limit %d: configuration must not "+
+						"be nil", service.Name, i)
+				}
+
 				// Validate required fields.
 				if rl.Requests <= 0 {
 					return fmt.Errorf("service %s rate "+
@@ -360,6 +366,11 @@ func prepareServices(services []*Service) error {
 					return fmt.Errorf("service %s rate "+
 						"limit %d: per duration must "+
 						"be positive", service.Name, i)
+				}
+				if rl.Burst < 0 {
+					return fmt.Errorf("service %s rate "+
+						"limit %d: burst must not be "+
+						"negative", service.Name, i)
 				}
 
 				// Compile path regex if provided.

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -570,6 +570,7 @@ func prepareServices(services []*Service) error {
 			// Create the rate limiter for this service.
 			service.rateLimiter = NewRateLimiter(
 				service.Name, service.RateLimits,
+				withManagedCacheMetric(),
 			)
 
 			log.Infof("Initialized rate limiter for service %s "+

--- a/proxy/service.go
+++ b/proxy/service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,6 +163,178 @@ type Service struct {
 	rateLimiter *RateLimiter
 }
 
+// cloneServices returns a deep copy of service configuration data. Runtime
+// state is deliberately not copied: each prepared snapshot owns its compiled
+// expressions, pricer, freebie store and rate limiter. This lets UpdateServices
+// prepare a new snapshot without mutating configuration that may still be in
+// use by an active request.
+func cloneServices(services []*Service) ([]*Service, error) {
+	clones := make([]*Service, len(services))
+	for i, service := range services {
+		if service == nil {
+			return nil, fmt.Errorf("service %d: configuration must not be nil",
+				i)
+		}
+
+		clone := *service
+		clone.Headers = cloneStringMap(service.Headers)
+		clone.Constraints = cloneStringMap(service.Constraints)
+		clone.AuthWhitelistPaths = append(
+			[]string(nil), service.AuthWhitelistPaths...,
+		)
+		clone.AuthSkipInvoiceCreationPaths = append(
+			[]string(nil), service.AuthSkipInvoiceCreationPaths...,
+		)
+
+		clone.RateLimits = make(
+			[]*RateLimitConfig, len(service.RateLimits),
+		)
+		for j, config := range service.RateLimits {
+			if config == nil {
+				continue
+			}
+
+			configClone := *config
+			configClone.compiledPathRegexp = nil
+			clone.RateLimits[j] = &configClone
+		}
+
+		clone.compiledHostRegexp = nil
+		clone.compiledPathRegexp = nil
+		clone.compiledAuthWhitelistPaths = nil
+		clone.compiledAuthSkipInvoiceCreationPaths = nil
+		clone.freebieDB = nil
+		clone.pricer = nil
+		clone.rateLimiter = nil
+
+		clones[i] = &clone
+	}
+
+	return clones, nil
+}
+
+// cloneStringMap copies a string map while preserving nil maps.
+func cloneStringMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+
+	clone := make(map[string]string, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+
+	return clone
+}
+
+// copyPreparedServiceConfig restores the caller-visible preparation effects
+// that UpdateServices historically applied in place. Runtime objects stay
+// private to the published snapshot, while successful updates still
+// materialize headers, normalize prices and make exported matching helpers work
+// on the caller's configuration. This function performs no fallible work and
+// must only be called after the prepared snapshot has passed all validation.
+func copyPreparedServiceConfig(configured, prepared []*Service) {
+	for i, preparedService := range prepared {
+		configuredService := configured[i]
+
+		copyStringMapInPlace(
+			&configuredService.Headers, preparedService.Headers,
+		)
+		if configuredService.Price != preparedService.Price {
+			configuredService.Price = preparedService.Price
+		}
+		if configuredService.Rewrite != preparedService.Rewrite {
+			configuredService.Rewrite = preparedService.Rewrite
+		}
+
+		copyCompiledRegexp(
+			&configuredService.compiledHostRegexp,
+			preparedService.compiledHostRegexp,
+		)
+		copyCompiledRegexp(
+			&configuredService.compiledPathRegexp,
+			preparedService.compiledPathRegexp,
+		)
+		copyCompiledRegexpSlice(
+			&configuredService.compiledAuthWhitelistPaths,
+			preparedService.compiledAuthWhitelistPaths,
+		)
+		copyCompiledRegexpSlice(
+			&configuredService.compiledAuthSkipInvoiceCreationPaths,
+			preparedService.compiledAuthSkipInvoiceCreationPaths,
+		)
+
+		for j, preparedRule := range preparedService.RateLimits {
+			copyCompiledRegexp(
+				&configuredService.RateLimits[j].compiledPathRegexp,
+				preparedRule.compiledPathRegexp,
+			)
+		}
+	}
+}
+
+// copyStringMapInPlace copies source into target while retaining the caller's
+// map identity. Successful service preparation historically materialized
+// header directives in that map.
+func copyStringMapInPlace(target *map[string]string, source map[string]string) {
+	if maps.Equal(*target, source) {
+		return
+	}
+	if *target == nil {
+		*target = cloneStringMap(source)
+		return
+	}
+
+	for key := range *target {
+		delete(*target, key)
+	}
+	for key, value := range source {
+		(*target)[key] = value
+	}
+}
+
+// copyCompiledRegexp avoids rewriting an unchanged caller-owned service during
+// unrelated updates. That keeps copy-back idempotent for configurations shared
+// with the admin service holder.
+func copyCompiledRegexp(target **regexp.Regexp, source *regexp.Regexp) {
+	if regexpsEqual(*target, source) {
+		return
+	}
+
+	*target = source
+}
+
+// copyCompiledRegexpSlice copies compiled patterns only when their expressions
+// changed.
+func copyCompiledRegexpSlice(target *[]*regexp.Regexp,
+	source []*regexp.Regexp) {
+
+	if len(*target) == len(source) {
+		equal := true
+		for i := range source {
+			if !regexpsEqual((*target)[i], source[i]) {
+				equal = false
+				break
+			}
+		}
+		if equal {
+			return
+		}
+	}
+
+	*target = append([]*regexp.Regexp(nil), source...)
+}
+
+// regexpsEqual reports whether two compiled expressions have equivalent source
+// patterns.
+func regexpsEqual(left, right *regexp.Regexp) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+
+	return left.String() == right.String()
+}
+
 // prepareRewrite validates and normalizes the rewrite configuration.
 func (s *Service) prepareRewrite() error {
 	if s.Rewrite.Prefix == "" {
@@ -296,17 +469,19 @@ func prepareServices(services []*Service) error {
 		}
 		service.compiledHostRegexp = compiledHostRegexp
 
-		// Compile the path regex.
+		// Compile the path regex. Assign once after successful compilation so
+		// a failed re-prepare leaves the prior compiled value intact.
+		var compiledPathRegexp *regexp.Regexp
 		if service.PathRegexp != "" {
-			compiledPathRegexp, err := regexp.Compile(
+			compiledPathRegexp, err = regexp.Compile(
 				service.PathRegexp,
 			)
 			if err != nil {
 				return fmt.Errorf("error compiling path "+
 					"regex: %w", err)
 			}
-			service.compiledPathRegexp = compiledPathRegexp
 		}
+		service.compiledPathRegexp = compiledPathRegexp
 
 		service.compiledAuthWhitelistPaths = make(
 			[]*regexp.Regexp, 0, len(service.AuthWhitelistPaths),

--- a/proxy/service_test.go
+++ b/proxy/service_test.go
@@ -46,6 +46,73 @@ func TestPrepareServicesRateLimitValidation(t *testing.T) {
 	}
 }
 
+// TestPrepareServicesClearsRateLimiter makes sure removing all rules during a
+// service update disables a previously initialized limiter.
+func TestPrepareServicesClearsRateLimiter(t *testing.T) {
+	service := &Service{
+		Name:       "test",
+		HostRegexp: ".*",
+		RateLimits: []*RateLimitConfig{{
+			Requests: 1,
+			Per:      time.Second,
+		}},
+	}
+
+	require.NoError(t, prepareServices([]*Service{service}))
+	require.NotNil(t, service.rateLimiter)
+
+	service.RateLimits = nil
+	require.NoError(t, prepareServices([]*Service{service}))
+	require.Nil(t, service.rateLimiter)
+}
+
+// TestPrepareServicesClearsCompiledRateLimitPattern makes sure reusing a rule
+// with an empty path expression restores its match-all behavior.
+func TestPrepareServicesClearsCompiledRateLimitPattern(t *testing.T) {
+	rule := &RateLimitConfig{
+		PathRegexp: "^/one$",
+		Requests:   1,
+		Per:        time.Second,
+	}
+	service := &Service{
+		Name:       "test",
+		HostRegexp: ".*",
+		RateLimits: []*RateLimitConfig{rule},
+	}
+
+	require.NoError(t, prepareServices([]*Service{service}))
+	require.False(t, rule.Matches("/two"))
+
+	rule.PathRegexp = ""
+	require.NoError(t, prepareServices([]*Service{service}))
+	require.True(t, rule.Matches("/two"))
+}
+
+// TestPrepareServicesFailedRateLimitCompilePreservesPattern makes sure a
+// failed re-prepare does not temporarily or permanently turn a path-specific
+// rule into a match-all rule.
+func TestPrepareServicesFailedRateLimitCompilePreservesPattern(t *testing.T) {
+	rule := &RateLimitConfig{
+		PathRegexp: "^/one$",
+		Requests:   1,
+		Per:        time.Second,
+	}
+	service := &Service{
+		Name:       "test",
+		HostRegexp: ".*",
+		RateLimits: []*RateLimitConfig{rule},
+	}
+
+	require.NoError(t, prepareServices([]*Service{service}))
+	require.True(t, rule.Matches("/one"))
+	require.False(t, rule.Matches("/two"))
+
+	rule.PathRegexp = "["
+	require.Error(t, prepareServices([]*Service{service}))
+	require.True(t, rule.Matches("/one"))
+	require.False(t, rule.Matches("/two"))
+}
+
 // TestExpandHeaderEnv makes sure ${NAME} environment references in service
 // header values are expanded at startup, and that a reference to an unset
 // variable fails rather than substituting an empty string.

--- a/proxy/service_test.go
+++ b/proxy/service_test.go
@@ -3,9 +3,48 @@ package proxy
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestPrepareServicesRateLimitValidation makes sure malformed rate limit
+// entries fail startup with actionable errors.
+func TestPrepareServicesRateLimitValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *RateLimitConfig
+		errMatch string
+	}{
+		{
+			name:     "nil config",
+			config:   nil,
+			errMatch: "configuration must not be nil",
+		},
+		{
+			name: "negative burst",
+			config: &RateLimitConfig{
+				Requests: 1,
+				Per:      time.Second,
+				Burst:    -1,
+			},
+			errMatch: "burst must not be negative",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := &Service{
+				Name:       "test",
+				HostRegexp: ".*",
+				RateLimits: []*RateLimitConfig{test.config},
+			}
+
+			err := prepareServices([]*Service{service})
+			require.ErrorContains(t, err, test.errMatch)
+		})
+	}
+}
 
 // TestExpandHeaderEnv makes sure ${NAME} environment references in service
 // header values are expanded at startup, and that a reference to an unset

--- a/proxy/service_update_test.go
+++ b/proxy/service_update_test.go
@@ -1,0 +1,207 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/aperture/auth"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateServicesCopiesRateLimitConfig makes sure a published service owns
+// its runtime state instead of sharing nested configuration pointers with the
+// caller.
+func TestUpdateServicesCopiesRateLimitConfig(t *testing.T) {
+	t.Setenv("APERTURE_UPDATE_HEADER", "first-value")
+
+	rule := &RateLimitConfig{
+		PathRegexp: "^/limited$",
+		Requests:   1,
+		Per:        time.Hour,
+	}
+	service := newUpdateTestService(t.Name(), rule)
+	service.Auth = auth.Level("on")
+	service.AuthWhitelistPaths = []string{"^/public$"}
+	service.AuthSkipInvoiceCreationPaths = []string{"^/no-invoice$"}
+	service.Headers = map[string]string{
+		"X-Upstream": "${APERTURE_UPDATE_HEADER}",
+	}
+	originalHeaders := service.Headers
+
+	p, err := New(
+		auth.NewMockAuthenticator(), []*Service{service}, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+
+	active := p.services[0]
+	require.NotSame(t, service, active)
+	require.NotSame(t, rule, active.RateLimits[0])
+	require.NotNil(t, rule.compiledPathRegexp)
+	require.Nil(t, service.rateLimiter)
+	require.False(t, active.RateLimits[0].Matches("/other"))
+	require.False(t, rule.Matches("/other"))
+	require.Equal(t, int64(defaultServicePrice), service.Price)
+	require.Equal(t, "first-value", service.Headers["X-Upstream"])
+	require.Equal(t, "first-value", originalHeaders["X-Upstream"])
+
+	publicReq := httptest.NewRequest("GET", "/public", nil)
+	require.Equal(t, auth.LevelOff, service.AuthRequired(publicReq))
+	noInvoiceReq := httptest.NewRequest("GET", "/no-invoice", nil)
+	require.True(t, service.SkipInvoiceCreation(noInvoiceReq))
+
+	// Mutating caller-owned configuration after publication must not alter
+	// the active snapshot.
+	rule.PathRegexp = ""
+	require.False(t, active.RateLimits[0].Matches("/other"))
+
+	// Successful preparation materializes header directives in the caller's
+	// map. An unrelated later update must not re-expand the original value.
+	t.Setenv("APERTURE_UPDATE_HEADER", "second-value")
+	require.NoError(t, p.UpdateServices([]*Service{service}))
+	require.Equal(t, "first-value", service.Headers["X-Upstream"])
+}
+
+// TestUpdateServicesFailureDoesNotCopyPreparedConfig makes sure caller-visible
+// normalization is committed only after every staged service validates.
+func TestUpdateServicesFailureDoesNotCopyPreparedConfig(t *testing.T) {
+	t.Setenv("APERTURE_FAILED_UPDATE_HEADER", "expanded")
+
+	rule := &RateLimitConfig{
+		PathRegexp: "^/candidate$",
+		Requests:   1,
+		Per:        time.Hour,
+	}
+	service := newUpdateTestService(t.Name(), rule)
+	service.Headers = map[string]string{
+		"X-Upstream": "${APERTURE_FAILED_UPDATE_HEADER}",
+	}
+	service.DynamicPrice.Metered = true
+
+	p, err := New(
+		auth.NewMockAuthenticator(),
+		[]*Service{newUpdateTestService(t.Name()+"-active", &RateLimitConfig{
+			Requests: 1,
+			Per:      time.Hour,
+		})}, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+	active := p.services[0]
+
+	err = p.UpdateServices([]*Service{service})
+	require.Error(t, err)
+	require.Equal(
+		t, "${APERTURE_FAILED_UPDATE_HEADER}",
+		service.Headers["X-Upstream"],
+	)
+	require.Zero(t, service.Price)
+	require.Nil(t, rule.compiledPathRegexp)
+	require.Same(t, active, p.services[0])
+}
+
+// TestUpdateServicesCertFailureDoesNotCopyPreparedConfig exercises the latest
+// fallible staging boundary: certificate loading happens after rate-limit
+// compilation, header materialization, price normalization and pricer setup.
+func TestUpdateServicesCertFailureDoesNotCopyPreparedConfig(t *testing.T) {
+	t.Setenv("APERTURE_CERT_FAILURE_HEADER", "expanded")
+
+	activeService := newUpdateTestService(
+		t.Name()+"-active", &RateLimitConfig{
+			Requests: 2,
+			Per:      time.Hour,
+			Burst:    2,
+		},
+	)
+	p, err := New(
+		auth.NewMockAuthenticator(), []*Service{activeService}, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+
+	active := p.services[0]
+	rule := &RateLimitConfig{
+		PathRegexp: "^/candidate$",
+		Requests:   1,
+		Per:        time.Hour,
+	}
+	candidate := newUpdateTestService(t.Name()+"-candidate", rule)
+	candidate.Headers = map[string]string{
+		"X-Upstream": "${APERTURE_CERT_FAILURE_HEADER}",
+	}
+	candidate.TLSCertPath = filepath.Join(t.TempDir(), "missing.pem")
+
+	err = p.UpdateServices([]*Service{candidate})
+	require.Error(t, err)
+	require.Equal(
+		t, "${APERTURE_CERT_FAILURE_HEADER}",
+		candidate.Headers["X-Upstream"],
+	)
+	require.Zero(t, candidate.Price)
+	require.Nil(t, rule.compiledPathRegexp)
+	require.Nil(t, candidate.rateLimiter)
+	require.Same(t, active, p.services[0])
+}
+
+// TestUpdateServicesRateLimitSnapshotConcurrent exercises the pointer-reuse
+// pattern used by runtime service updates while an old limiter is active. Run
+// under the race detector, this catches writes to shared compiled regexps.
+func TestUpdateServicesRateLimitSnapshotConcurrent(t *testing.T) {
+	rule := &RateLimitConfig{
+		PathRegexp: "^/limited$",
+		Requests:   100,
+		Per:        time.Second,
+		Burst:      100,
+	}
+	service := newUpdateTestService(t.Name(), rule)
+
+	p, err := New(
+		auth.NewMockAuthenticator(), []*Service{service}, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+
+	oldLimiter := p.services[0].rateLimiter
+	request := httptest.NewRequest("GET", "/not-limited", nil)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for range 10_000 {
+			allowed, _ := oldLimiter.Allow(request, "test-key")
+			if !allowed {
+				t.Error("non-matching request was rate limited")
+				return
+			}
+		}
+	}()
+
+	for range 200 {
+		require.NoError(t, p.UpdateServices([]*Service{service}))
+	}
+	wg.Wait()
+	require.Zero(t, oldLimiter.Size())
+}
+
+func newUpdateTestService(name string, rule *RateLimitConfig) *Service {
+	return &Service{
+		Name:       name,
+		HostRegexp: ".*",
+		PathRegexp: ".*",
+		Auth:       auth.Level("off"),
+		RateLimits: []*RateLimitConfig{rule},
+	}
+}

--- a/proxy/service_update_test.go
+++ b/proxy/service_update_test.go
@@ -129,6 +129,14 @@ func TestUpdateServicesCertFailureDoesNotCopyPreparedConfig(t *testing.T) {
 	})
 
 	active := p.services[0]
+	request := httptest.NewRequest("GET", "/limited", nil)
+	allowed, _ := active.rateLimiter.Allow(request, "active-key")
+	require.True(t, allowed)
+	labels := map[string]string{"service": activeService.Name}
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
 	rule := &RateLimitConfig{
 		PathRegexp: "^/candidate$",
 		Requests:   1,
@@ -150,6 +158,9 @@ func TestUpdateServicesCertFailureDoesNotCopyPreparedConfig(t *testing.T) {
 	require.Nil(t, rule.compiledPathRegexp)
 	require.Nil(t, candidate.rateLimiter)
 	require.Same(t, active, p.services[0])
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
 }
 
 // TestUpdateServicesRateLimitSnapshotConcurrent exercises the pointer-reuse
@@ -196,6 +207,198 @@ func TestUpdateServicesRateLimitSnapshotConcurrent(t *testing.T) {
 	require.Zero(t, oldLimiter.Size())
 }
 
+// TestUpdateServicesRateLimitMetricsTransactional makes sure a failed update
+// leaves both the active limiter and its cache gauge unchanged. Successful
+// replacement resets the new cache, and removing the limiter removes its
+// gauge.
+func TestUpdateServicesRateLimitMetricsTransactional(t *testing.T) {
+	rule := &RateLimitConfig{
+		PathRegexp: "^/limited$",
+		Requests:   2,
+		Per:        time.Hour,
+		Burst:      2,
+	}
+	service := newUpdateTestService(t.Name(), rule)
+
+	p, err := New(
+		auth.NewMockAuthenticator(), []*Service{service}, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+
+	labels := map[string]string{"service": service.Name}
+	active := p.services[0]
+	require.Equal(t, 0.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	request := httptest.NewRequest("GET", "/limited", nil)
+	allowed, _ := active.rateLimiter.Allow(request, "test-key")
+	require.True(t, allowed)
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	// Exercise a validation failure that occurs after the replacement rate
+	// limiter has been constructed. It must not reset the live cache gauge.
+	lateFailure := *service
+	lateFailure.DynamicPrice.Metered = true
+	require.Error(t, p.UpdateServices([]*Service{&lateFailure}))
+	require.Same(t, active, p.services[0])
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	badRule := *rule
+	badRule.PathRegexp = "["
+	badService := *service
+	badService.RateLimits = []*RateLimitConfig{&badRule}
+	require.Error(t, p.UpdateServices([]*Service{&badService}))
+	require.Same(t, active, p.services[0])
+	require.False(t, active.RateLimits[0].Matches("/other"))
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	require.NoError(t, p.UpdateServices([]*Service{service}))
+	require.Equal(t, 0.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	withoutLimits := *service
+	withoutLimits.RateLimits = nil
+	require.NoError(t, p.UpdateServices([]*Service{&withoutLimits}))
+	_, ok := prometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	)
+	require.False(t, ok)
+}
+
+// TestRateLimitCacheMetricsMultipleProxies makes sure replacing one Proxy's
+// limiter cannot delete or overwrite another active Proxy's contribution that
+// uses the same service label.
+func TestRateLimitCacheMetricsMultipleProxies(t *testing.T) {
+	serviceName := t.Name()
+	newService := func() *Service {
+		return newUpdateTestService(serviceName, &RateLimitConfig{
+			Requests: 2,
+			Per:      time.Hour,
+			Burst:    2,
+		})
+	}
+
+	firstService := newService()
+	first, err := New(
+		auth.NewMockAuthenticator(), []*Service{firstService}, nil, nil,
+	)
+	require.NoError(t, err)
+	firstClosed := false
+	t.Cleanup(func() {
+		if !firstClosed {
+			require.NoError(t, first.Close())
+		}
+	})
+
+	secondService := newService()
+	second, err := New(
+		auth.NewMockAuthenticator(), []*Service{secondService}, nil, nil,
+	)
+	require.NoError(t, err)
+	secondClosed := false
+	t.Cleanup(func() {
+		if !secondClosed {
+			require.NoError(t, second.Close())
+		}
+	})
+
+	request := httptest.NewRequest("GET", "/limited", nil)
+	allowed, _ := first.services[0].rateLimiter.Allow(request, "first-key")
+	require.True(t, allowed)
+	allowed, _ = second.services[0].rateLimiter.Allow(request, "second-key")
+	require.True(t, allowed)
+
+	labels := map[string]string{"service": serviceName}
+	require.Equal(t, 2.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	require.NoError(t, first.Close())
+	firstClosed = true
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	allowed, _ = second.services[0].rateLimiter.Allow(request, "third-key")
+	require.True(t, allowed)
+	require.Equal(t, 2.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	require.NoError(t, second.Close())
+	secondClosed = true
+	_, ok := prometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	)
+	require.False(t, ok)
+}
+
+// TestRateLimitManagedMetricsDoNotDeleteLegacyGauge makes sure Proxy snapshot
+// lifecycle operations only affect active_cache_size. The original cache_size
+// gauge remains compatible with standalone RateLimiter users.
+func TestRateLimitManagedMetricsDoNotDeleteLegacyGauge(t *testing.T) {
+	serviceName := t.Name()
+	standalone := NewRateLimiter(serviceName, []*RateLimitConfig{{
+		Requests: 2,
+		Per:      time.Hour,
+		Burst:    2,
+	}})
+	request := httptest.NewRequest("GET", "/limited", nil)
+	allowed, _ := standalone.Allow(request, "standalone-key")
+	require.True(t, allowed)
+
+	service := newUpdateTestService(serviceName, &RateLimitConfig{
+		Requests: 2,
+		Per:      time.Hour,
+		Burst:    2,
+	})
+	p, err := New(
+		auth.NewMockAuthenticator(), []*Service{service}, nil, nil,
+	)
+	require.NoError(t, err)
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			require.NoError(t, p.Close())
+		}
+	})
+
+	labels := map[string]string{"service": serviceName}
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_cache_size", labels,
+	))
+	require.Equal(t, 0.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	))
+
+	require.NoError(t, p.Close())
+	closed = true
+	_, ok := prometheusGaugeValue(
+		t, "aperture_ratelimit_active_cache_size", labels,
+	)
+	require.False(t, ok)
+	require.Equal(t, 1.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_cache_size", labels,
+	))
+
+	allowed, _ = standalone.Allow(request, "standalone-key-2")
+	require.True(t, allowed)
+	require.Equal(t, 2.0, mustPrometheusGaugeValue(
+		t, "aperture_ratelimit_cache_size", labels,
+	))
+}
+
 func newUpdateTestService(name string, rule *RateLimitConfig) *Service {
 	return &Service{
 		Name:       name,
@@ -204,4 +407,15 @@ func newUpdateTestService(name string, rule *RateLimitConfig) *Service {
 		Auth:       auth.Level("off"),
 		RateLimits: []*RateLimitConfig{rule},
 	}
+}
+
+func mustPrometheusGaugeValue(t *testing.T, name string,
+	labels map[string]string) float64 {
+
+	t.Helper()
+
+	value, ok := prometheusGaugeValue(t, name, labels)
+	require.True(t, ok)
+
+	return value
 }


### PR DESCRIPTION
## Summary

- make multi-rule rate-limit decisions atomic for each exact client key, with provisional admissions that can be committed or refunded safely
- keep rules with identical path expressions independent and fail closed when one admission cannot fit within the configured cache bound
- apply rate limiting consistently to authenticated, unauthenticated, zero-priced, and freebie request paths without spending freebie quota on rejected requests
- stage service updates in isolated snapshots and publish them transactionally, while preserving the caller-visible preparation behavior of successful updates
- preserve the existing Prometheus metric semantics and add rule-specific counters plus an active-snapshot cache gauge
- validate malformed rate-limit entries and document cache, identity, and deployment scope

## Motivation

The limiter previously protected individual cache operations, but a request matching multiple rules was not an atomic operation. Concurrent requests for the same client could interleave reservations and refunds, allowing partial quota consumption. Cache identity was also based on the path expression, which collapsed distinct rules that intentionally used the same expression with different horizons.

Runtime service updates prepared caller-owned service and rule objects before publication. Reusing those pointers could race active limiter matching, expose partially prepared state after a failed update, and reset cache observability before the replacement was known to be valid. The freebie path also tallied its quota before knowing whether the limiter would admit the request.

## Impact

- all matching rules now admit or reject a request as one unit
- rejected multi-rule requests do not consume capacity from rules that would otherwise allow them
- same-client concurrency is deterministic without blocking unrelated clients
- failed freebie bookkeeping refunds provisional rate-limit capacity, while rate-limit rejection leaves freebie quota untouched
- failed service updates leave the live limiter, caller configuration, and active cache metric unchanged
- successful updates continue to normalize caller-visible configuration as before
- non-matching requests avoid cache entries and keyed-lock allocation

## Commit structure

The changes are split by independently reviewable issue and ordered by
dependency:

1. `proxy: validate rate limit configurations`
   - reject nil rules and invalid burst/window values instead of panicking or
     constructing unusable limiters
2. `proxy: reset rate limit state on service reuse`
   - clear stale limiter/regexp state and preserve the last valid compiled rule
     when re-preparation fails
3. `proxy: keep duplicate rate limit rules independent`
   - key cached buckets by rule identity so equal path expressions can enforce
     different horizons
4. `proxy: make multi-rule admissions atomic per client`
   - serialize exact-client decisions and refund every reservation when one
     matching rule rejects
5. `proxy: release finalized rate limit admission state`
   - drop retained reservation references and recycle keyed locks after commit
     or cancellation
6. `proxy: fail closed on undersized rate limit caches`
   - preserve the configured hard bound without allowing self-eviction to
     refresh bursts
7. `proxy: expose metrics for distinct rate limit rules`
   - add semantic rule-level counters while preserving the existing aggregate
     counter behavior
8. `proxy: rate limit zero-priced requests`
   - close the unauthenticated zero-price bypass
9. `proxy: coordinate freebie and rate limit reservations`
   - avoid spending freebie quota on denied requests and refund limiter capacity
     when freebie persistence fails
10. `proxy: publish service updates from isolated snapshots`
    - stage and validate immutable runtime state before atomically publishing it
11. `proxy: track cache metrics for active limiter snapshots`
    - aggregate active cache state across updates and same-name proxy instances
12. `proxy: document and verify rate limiter enforcement scope`
    - document process/cache/client boundaries and verify authenticated token-ID
      keying

## Validation

- `go test -race -p 1 ./...`
- `go vet ./...`
- focused rate-limiter and update tests run at each commit boundary
- final tree verified identical to the previously reviewed single-commit patch
- `git diff --check`
