### PR TITLE
proxy+auth+meterd: meter MPP charges and carry streamed responses

### DIFF
--- a/aperture.go
+++ b/aperture.go
@@ -1726,10 +1726,9 @@ func createProxy(cfg *Config, services []*proxy.Service,
 		}
 		if len(meteredServices) > 0 {
 			mppAuth.SetReusableChargePolicy(
-				func(serviceName string) bool {
-					_, ok := meteredServices[serviceName]
-					return ok
-				},
+				reusableChargePolicyForServices(
+					meteredServices,
+				),
 			)
 		}
 
@@ -2017,4 +2016,30 @@ func allowCORS(handler http.Handler, origins []string) http.Handler {
 		// chain of handlers.
 		handler.ServeHTTP(w, r)
 	})
+}
+
+// reusableChargePolicyForServices builds the predicate deciding which
+// resource names may re-present a charge credential.
+//
+// The authenticator is handed the resource name, which for a dynamically
+// priced service is the service name with the request path appended
+// (Service.ResourceName), so a metered service is recognized by prefix
+// rather than equality: "inference" covers "inference/v1/chat/completions".
+// The separator is required so a service named "inference" does not
+// accidentally cover one named "inference2".
+func reusableChargePolicyForServices(
+	metered map[string]struct{}) func(string) bool {
+
+	return func(resourceName string) bool {
+		for name := range metered {
+			if resourceName == name {
+				return true
+			}
+			if strings.HasPrefix(resourceName, name+"/") {
+				return true
+			}
+		}
+
+		return false
+	}
 }

--- a/aperture.go
+++ b/aperture.go
@@ -1706,6 +1706,23 @@ func createProxy(cfg *Config, services []*proxy.Service,
 			return nil, nil, err
 		}
 
+		// On metered services the charge credential is the key to a
+		// prepaid usage bundle, so it stays presentable until the
+		// pricer refuses it, exactly like an L402 token. Everywhere
+		// else the spec's strict single-use rule stands.
+		meteredServices := make(map[string]struct{})
+		for _, svc := range services {
+			if svc.DynamicPrice.Enabled && svc.DynamicPrice.Metered {
+				meteredServices[svc.Name] = struct{}{}
+			}
+		}
+		if len(meteredServices) > 0 {
+			mppAuth.SetReusableChargePolicy(
+				func(serviceName string) bool {
+					_, ok := meteredServices[serviceName]
+					return ok
+				},
+			)
 		// The authenticator runs a background sweep over the records of
 		// spent payments, which the caller stops along with the rest of
 		// the proxy.

--- a/aperture.go
+++ b/aperture.go
@@ -469,6 +469,12 @@ func (a *Aperture) Start(errChan chan error, shutdown <-chan struct{}) error {
 	// while writing the whole way through; what the timeout should kill
 	// is a stall, and the proxy pushes the deadline forward on every
 	// write to make it mean exactly that.
+	//
+	// Operators should therefore size writetimeout to the worst-case gap
+	// between writes, not to total response duration: a backend that
+	// legitimately pauses longer than the window between chunks, a
+	// reasoning model thinking silently being the canonical case, is cut
+	// off as a stall even though the client is healthy.
 	a.proxy.SetWriteDeadlineWindow(a.cfg.WriteTimeout)
 
 	handler := http.HandlerFunc(a.proxy.ServeHTTP)

--- a/aperture.go
+++ b/aperture.go
@@ -463,6 +463,14 @@ func (a *Aperture) Start(errChan chan error, shutdown <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
+	// The write timeout is applied as a rolling idle window on proxied
+	// responses rather than a single absolute deadline. A streamed
+	// inference response routinely outlives any sane absolute timeout
+	// while writing the whole way through; what the timeout should kill
+	// is a stall, and the proxy pushes the deadline forward on every
+	// write to make it mean exactly that.
+	a.proxy.SetWriteDeadlineWindow(a.cfg.WriteTimeout)
+
 	handler := http.HandlerFunc(a.proxy.ServeHTTP)
 	a.httpsServer = &http.Server{
 		Addr:         a.cfg.ListenAddr,
@@ -1723,6 +1731,8 @@ func createProxy(cfg *Config, services []*proxy.Service,
 					return ok
 				},
 			)
+		}
+
 		// The authenticator runs a background sweep over the records of
 		// spent payments, which the caller stops along with the rest of
 		// the proxy.

--- a/aperture_internal_test.go
+++ b/aperture_internal_test.go
@@ -1,0 +1,32 @@
+package aperture
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReusableChargePolicyForServices pins the shape of the name the policy
+// is asked about: the authenticator passes the resource name, which for a
+// dynamically priced service is the service name with the request path
+// appended. Matching on equality alone silently re-enables single-use
+// charges on every metered service, which is exactly the failure a live run
+// caught.
+func TestReusableChargePolicyForServices(t *testing.T) {
+	t.Parallel()
+
+	policy := reusableChargePolicyForServices(map[string]struct{}{
+		"inference": {},
+	})
+
+	// The resource name of a dynamically priced service carries the path.
+	require.True(t, policy("inference/v1/chat/completions"))
+
+	// A service without dynamic pricing is asked about by bare name.
+	require.True(t, policy("inference"))
+
+	// Prefix matching must not bleed across the path separator.
+	require.False(t, policy("inference2/v1/chat/completions"))
+	require.False(t, policy("inference2"))
+	require.False(t, policy("other"))
+}

--- a/auth/mpp_authenticator.go
+++ b/auth/mpp_authenticator.go
@@ -60,6 +60,20 @@ type MPPAuthenticator struct {
 	// constructor refuses to build one.
 	chargeStore ChargeStore
 
+	// reusableChargePolicy reports whether a service treats charge
+	// credentials as re-presentable rather than single use. Nil means no
+	// service does, which is the spec's strict rule.
+	//
+	// The one deployment that wants re-presentation is a metered service.
+	// There, the payment buys a usage bundle rather than a single request,
+	// and the metering pipeline debits the bundle per request until it is
+	// exhausted, at which point the pricer refuses the request and a fresh
+	// 402 is minted. The bundle draw-down is the spend, so consuming the
+	// credential on first use would strand everything the buyer paid for
+	// beyond one request. This mirrors exactly how an L402 token behaves
+	// on the same service.
+	reusableChargePolicy func(serviceName string) bool
+
 	// pruneInterval is how often expired consumption records are swept.
 	pruneInterval time.Duration
 
@@ -137,6 +151,19 @@ func NewMPPAuthenticator(challenger mint.Challenger, checker InvoiceChecker,
 
 // Start launches the background sweep that keeps the consumption record table
 // from growing without bound. It is safe to call more than once.
+// SetReusableChargePolicy installs the predicate that decides which services
+// treat charge credentials as re-presentable rather than single use. It is
+// meant to be called once, between construction and Start, with a predicate
+// naming the metered services: on those, the payment buys a bundle whose
+// draw-down is the spend, so the credential must stay presentable until the
+// pricer refuses it. Passing nil restores the strict single-use rule
+// everywhere.
+func (a *MPPAuthenticator) SetReusableChargePolicy(
+	policy func(serviceName string) bool) {
+
+	a.reusableChargePolicy = policy
+}
+
 func (a *MPPAuthenticator) Start() {
 	a.started.Do(func() {
 		a.wg.Add(1)
@@ -349,10 +376,24 @@ func (a *MPPAuthenticator) Accept(header *http.Header,
 		return false
 	}
 	if !consumed {
-		log.Warnf("MPP: Refusing replayed charge credential for "+
-			"payment hash %x on service %s", paymentHash[:],
-			serviceName)
-		return false
+		// On a metered service the credential is the key to a prepaid
+		// bundle, not a single request, so a repeat presentation is
+		// the normal way the buyer spends the rest of what it paid
+		// for. The metering pipeline debits each request against the
+		// bundle and refuses when it runs dry; that draw-down, not
+		// this record, is what bounds the spend there.
+		if a.reusableChargePolicy != nil &&
+			a.reusableChargePolicy(serviceName) {
+
+			log.Debugf("MPP: Charge credential re-presented for "+
+				"payment hash %x on metered service %s",
+				paymentHash[:], serviceName)
+		} else {
+			log.Warnf("MPP: Refusing replayed charge credential "+
+				"for payment hash %x on service %s",
+				paymentHash[:], serviceName)
+			return false
+		}
 	}
 
 	log.Debugf("MPP: Charge credential accepted for service %s",

--- a/auth/mpp_authenticator_test.go
+++ b/auth/mpp_authenticator_test.go
@@ -847,3 +847,48 @@ func TestMPPAuthenticatorAcceptsOncePerPayment(t *testing.T) {
 		}
 	})
 }
+
+// TestMPPAuthenticatorReusableChargeOnMeteredService verifies that the
+// reusable-charge policy turns a repeat presentation from a refused replay
+// into an accepted request, and only on the services the policy names.
+//
+// On a metered service the credential is the key to a prepaid usage bundle:
+// the metering pipeline debits every request against the bundle and refuses
+// when it runs dry, so the draw-down is what bounds the spend and the
+// credential has to stay presentable. Everywhere else the spec's single-use
+// rule stands.
+func TestMPPAuthenticatorReusableChargeOnMeteredService(t *testing.T) {
+	checker := newMockInvoiceChecker()
+	auth, _ := newTestChargeAuth(t, &mockChallenger{}, checker)
+
+	auth.SetReusableChargePolicy(func(serviceName string) bool {
+		return serviceName == "metered-service"
+	})
+
+	// On the metered service, the same credential keeps working: the
+	// second presentation is the buyer spending the rest of its bundle.
+	h, _ := paidCredential(t, checker)
+	require.True(t, auth.Accept(&h, "metered-service"))
+	require.True(t, auth.Accept(&h, "metered-service"))
+
+	// On a service the policy does not name, the strict rule stands: the
+	// first presentation spends the payment and the second is a replay.
+	h2, _ := paidCredential(t, checker)
+	require.True(t, auth.Accept(&h2, "strict-service"))
+	require.False(t, auth.Accept(&h2, "strict-service"))
+}
+
+// TestMPPAuthenticatorNilReusablePolicyStaysStrict verifies that clearing the
+// policy restores the single-use rule everywhere, so a deployment that
+// removes its metered services does not keep serving replays.
+func TestMPPAuthenticatorNilReusablePolicyStaysStrict(t *testing.T) {
+	checker := newMockInvoiceChecker()
+	auth, _ := newTestChargeAuth(t, &mockChallenger{}, checker)
+
+	auth.SetReusableChargePolicy(func(string) bool { return true })
+	auth.SetReusableChargePolicy(nil)
+
+	h, _ := paidCredential(t, checker)
+	require.True(t, auth.Accept(&h, "metered-service"))
+	require.False(t, auth.Accept(&h, "metered-service"))
+}

--- a/docs/metering.md
+++ b/docs/metering.md
@@ -1,0 +1,249 @@
+# Metered pricing: meterd, L402, and MPP
+
+Aperture can sell requests one at a time, or it can sell a prepaid bundle of
+usage and draw it down as requests flow. This document describes the second
+mode: what the meter is, how a bundle lives and dies, and how each of the three
+credential schemes settles its requests against it: L402, and the charge and
+session intents of the Payment HTTP Authentication Scheme (MPP). It closes with what changes when responses stream.
+
+The running example throughout is the deployment this design came from: an
+OpenAI-compatible inference endpoint where a buyer pays 2,000 satoshis for a
+bundle of 1,000,000 model tokens, then spends that bundle a few dozen tokens at
+a time, one chat completion per request.
+
+## The shape of the problem
+
+A fixed price per request is the wrong unit for inference. One request costs
+the seller a few dozen upstream tokens, the next costs four thousand, and the
+seller only learns which after the response has been served. Pricing every
+request at the worst case overcharges nearly everyone; pricing at the average
+invites abuse.
+
+Metering splits the problem in two. The *payment* happens once, up front, for a
+bundle of usage at a known price. The *accounting* happens per request, after
+the fact, from the usage the upstream actually reported. The credential the
+buyer paid for stops being a ticket for one request and becomes the key to a
+balance.
+
+## The pieces
+
+Three processes cooperate, joined by one gRPC surface:
+
+- **Aperture** terminates the payment protocols, proxies requests to the
+  backend, and observes responses. It holds no pricing or balance state of its
+  own.
+- **A price server** implements the `pricesrpc` service. It quotes prices,
+  books bundles, admits or refuses requests against their balances, and debits
+  reported usage. Aperture is configured to consult it per service via
+  `dynamicprice` in the service stanza; setting `metered: true` there is what
+  turns on the per-request flow described below.
+- **meterd** is the reference price server that ships in this repository. It
+  keeps its bundles in a JSON state file and its rates in static config, which
+  is enough for development and small deployments. Production deployments
+  embed the same `meterd.Server` behind their own storage and rate source: the
+  `Store` and `RateSource` interfaces are the two seams, so a durable
+  implementation replaces the state file with a database and the static rates
+  with a live price feed without touching the protocol logic.
+
+The `pricesrpc` calls, in the order a bundle meets them:
+
+| RPC | Who calls it, when | What it does |
+|---|---|---|
+| `GetPrice` | Aperture, before minting a 402 | Quotes the bundle price for this request's model |
+| `ChallengeMinted` | Aperture, as the 402 is minted | Books a bundle under the challenge's token ID |
+| `AuthorizeRequest` | Aperture, per authenticated request | Admits or refuses against the balance; reserves an estimate |
+| `ReportUsage` | Aperture, when the response finishes | Debits actual usage; releases the reservation |
+| `QuoteSession` / `SettleSession` | Aperture, for MPP sessions only | Session accounting; described in its own section below |
+
+## The life of a bundle
+
+A bundle is born when a 402 is minted, not when it is paid. `GetPrice` reads
+the request body, resolves the model, and quotes the bundle: at the blended
+rate of (input + output) / 2 millisatoshis per token, 1,000,000 tokens of a
+model priced at 1 and 2 msat comes to 1,500 sats. `ChallengeMinted` then books
+that bundle under the challenge's token ID, so that when the payment arrives
+there is already a balance for the credential to unlock. A booking whose
+challenge is never paid expires quietly after ten minutes; booking is cheap,
+and most 402s are minted for buyers who already hold a credential and simply
+retried too late.
+
+From then on, every authenticated request runs the same loop:
+
+1. `AuthorizeRequest` checks the balance. If the bundle covers the request, it
+   *reserves* an estimate: the request's own `max_tokens` when the body names
+   one, the configured `estimatedtokens` (default 4,096) otherwise. The
+   reservation is what keeps ten concurrent requests from each being admitted
+   against the same last thousand tokens; it is a hold, not a charge.
+2. The request proxies to the backend, and aperture wraps the response body so
+   the final bytes are captured as they pass. Nothing is buffered and nothing
+   is rewritten; the wrapper keeps a bounded tail (16 KiB by default,
+   `usagetailbytes` to change it) of what flowed.
+3. When the body finishes, `ReportUsage` carries that tail to the price
+   server. The server extracts the usage object the upstream reported, debits
+   the true token count, and releases the exact reservation. When the
+   prompt/completion split is known, the debit is weighted by direction, so an
+   all-output workload pays the output rate rather than hiding behind the
+   blend. The division rounds up: the msat value drawn from the bundle always
+   covers the msat value served.
+
+When a request would overdraw the bundle, `AuthorizeRequest` refuses it and
+names the price of the next bundle, aperture mints a fresh 402, and the cycle
+starts again. Exhaustion, not any property of the credential, is what ends a
+bundle's life.
+
+One consequence deserves emphasis: the credential and the balance are separate
+things joined by a key. Everything below is about what that key is for each
+scheme, because the key is where the schemes differ.
+
+## How L402 requests are metered
+
+An L402 credential is a macaroon plus the preimage of the invoice the buyer
+paid. The macaroon's identifier embeds a random token ID, and that ID is the
+metering key: `ChallengeMinted` reads it out of the freshly minted challenge
+macaroon, and every later request's ID is read back out of the credential the
+buyer presents.
+
+The buyer may present that credential three ways, and metering accepts all
+three, because the authenticator does: the `Authorization: L402` header
+carrying macaroon and preimage separately, or a hex macaroon with the preimage
+as a caveat in either the `Macaroon` or `Grpc-Metadata-Macaroon` header. A
+form the authenticator accepts but the meter did not see would be unlimited
+free service, so the two lists are deliberately the same list.
+
+Replaying an L402 credential is not an attack here; it is the product. The
+buyer pays once, then presents the same macaroon and preimage on every request
+until the bundle refuses. A malformed credential on a metered service is
+refused outright rather than passed through unmetered, for the same reason the
+header lists match: on a metered service, "not metered" and "free" are the
+same word.
+
+## How MPP charge requests are metered
+
+The Payment HTTP Authentication Scheme (MPP) arrives alongside L402 when
+aperture runs with `--authenticator.enablempp`: the same 402 then carries an
+LSAT offer, an L402 offer, and a Payment offer, and the buyer chooses a door.
+The Payment charge offer mints its own invoice, distinct from the L402
+offer's, which raises the question the L402 section never had to ask: what key
+joins this door to a bundle?
+
+The answer is the payment hash. The charge offer's request object carries the
+invoice and its payment hash; `ChallengeMinted` books a second bundle for the
+same 402, keyed by that hash. At request time the key is derived from the
+credential itself: the payload's preimage hashes to exactly the payment hash
+of the invoice it settled, so the proof of payment and the bundle key are the
+same 32 bytes. Nothing needs to be looked up and nothing needs to be trusted
+from the echoed challenge; the preimage was already verified by the
+authenticator before metering runs.
+
+Each 402 therefore books two bundles, one per door, at the same price.
+Whichever offer the buyer pays is the bundle that gets drawn down; the sibling
+booking is never activated and expires with the other unpaid bookings.
+
+Charge credentials on a metered service are also re-presentable, which is a
+deliberate departure from the scheme's default. The Payment spec treats a
+charge as buying one request, and on unmetered services aperture enforces
+exactly that: a consumed charge stays consumed. On a metered service that rule
+would strand the bundle, since the buyer paid for a million tokens and could
+present the credential once. So the single-use rule yields to the same rule
+L402 lives by: the credential stays presentable, the bundle draw-down is the
+spend, and the pricer refusing an exhausted bundle is what retires the
+credential. The consumption record is still written on first use, so the audit
+trail survives the policy.
+
+A charge credential is not service-bound the way an L402 macaroon is (the
+macaroon carries a service caveat; the Payment challenge HMAC covers realm,
+method, intent, request, and expiry, but no service name). Model mismatch
+still refuses cross-model use, and the buyer can never spend more than the one
+balance they paid for, so the exposure is attribution across same-model
+metered services rather than overspend. Binding the service into the
+challenge's `opaque` parameter, which the HMAC covers and the client must echo
+verbatim, is the natural tightening when a deployment needs it.
+
+## How MPP sessions are metered
+
+Sessions are the third door, enabled with `--authenticator.enablesessions`,
+and they run on different accounting because they solve a different problem: a
+charge pays per request and a bundle pays per model, but a session holds a
+*deposit* that many requests draw against, with a refund of whatever is left
+when the buyer closes it.
+
+The division of labor is inverted from the bundle flow. Aperture's session
+store owns the balance: the deposit credited at open, the estimated deduction
+per bearer request, the top-up credits, the refund at close. The price server
+is consulted twice per request rather than asked to keep state:
+
+- `QuoteSession` prices one request up front, and aperture deducts that
+  estimate from the session balance when it admits the bearer (a request
+  riding the open session, presenting its ID and deposit preimage rather
+  than a fresh payment).
+- `SettleSession` runs when the response finishes, with the same captured
+  tail the bundle flow uses. The price server recomputes the true cost from
+  the reported usage, and aperture reconciles the estimate against it, so the
+  session ends up debited for what was actually served.
+
+When the tail carries no parseable usage, the session settles at the estimate
+rather than at zero. That conservative fallback predates the streaming work
+and is the model the bundle path now follows for abandoned streams.
+
+## Streaming
+
+Streamed responses change nothing about the protocol and two things about the
+mechanics.
+
+The first is where the usage lives. A JSON response carries its usage object
+in the body; an SSE stream carries it in the final data chunk, when the client
+asked for it with `stream_options: {"include_usage": true}`, and some
+upstreams also report running totals on every chunk. The captured tail is
+parsed accordingly: the extractor walks the `data:` lines, takes the last
+usage-bearing chunk, and falls back to brace-matching a usage object out of a
+tail that got truncated mid-line. Aperture also strips the client's
+`Accept-Encoding` on metered requests so the observed tail is plaintext; a
+gzip tail would parse as nothing, and nothing would be billed. If a provider's
+final chunk can exceed 16 KiB (large tool-call arguments stacked on top of the
+usage object), raise `usagetailbytes`.
+
+The second is what happens when nobody waits for that final chunk. A client
+that disconnects mid-generation takes the usage object with it: the upstream
+already produced (and billed the seller for) every token up to the
+disconnect, and the tail holds content chunks with no usage. Those responses,
+incomplete but successful and non-empty, settle at the reservation estimate,
+exactly as sessions always have. The estimate is the ceiling the request named
+in its own `max_tokens`, so the buyer chooses the abandonment penalty, and a
+response that produced no bytes at all still costs nothing. Upstreams that
+report running totals per chunk sidestep the whole question, since even an
+abandoned tail then carries a parseable count and the exact partial usage is
+billed.
+
+One operator note belongs with this: aperture applies its configured
+`writetimeout` to proxied responses as a rolling window rather than a single
+absolute deadline, pushing the connection's write deadline forward on each
+write and refusing the extension once the gap between writes exceeds the
+window. A streamed generation therefore lives as long as it keeps flowing and
+dies when it stalls. Size `writetimeout` to the worst-case gap between
+chunks, not to total stream duration: a reasoning model that thinks silently
+for longer than the window is indistinguishable from a stall and is cut off.
+
+## Configuration quick reference
+
+On the aperture side, per service:
+
+```yaml
+services:
+  - name: "inference"
+    # ...
+    dynamicprice:
+      enabled: true
+      grpcaddress: "127.0.0.1:10025"
+      insecure: true
+      metered: true
+```
+
+and globally, the knobs streaming cares about: `writetimeout` (the rolling
+idle window described above) and the authenticator flags `enablempp` and
+`enablesessions` for the Payment doors.
+
+On the meterd side: `bundletokens` (bundle size), `estimatedtokens` (the
+reservation and abandonment fallback when a request names no `max_tokens`),
+`usagetailbytes` (tail capture, up to 1 MiB), and the per-model
+`inputmsatpertoken` / `outputmsatpertoken` rates. `meterd --help` carries the
+full list, and `sample-conf.yaml` shows the service stanza in context.

--- a/meterd/server.go
+++ b/meterd/server.go
@@ -492,11 +492,34 @@ func (s *Server) ReportUsage(_ context.Context,
 				"debited", req.TokenId, req.Path)
 		} else {
 			log.Debugf("No usage object found for token %s "+
-				"(path %s, status %d, complete %v), nothing "+
-				"debited", req.TokenId, req.Path,
-				req.HttpStatus, req.Complete)
+				"(path %s, status %d, complete %v)",
+				req.TokenId, req.Path, req.HttpStatus,
+				req.Complete)
 		}
 	}
+
+	// Resolve the reservation to release up front, since an abandoned
+	// stream settles at exactly this estimate below. An exact release
+	// keeps mismatched estimates from accumulating into phantom exhaustion
+	// on a bundle with real balance left; the fallback covers reports
+	// predating the reservation echo.
+	release := req.ReservedEstimate
+	if release <= 0 {
+		release = s.cfg.EstimatedTokens
+	}
+
+	// An incomplete successful response that carried bytes but no usage
+	// object is a streamed generation the client walked away from: the
+	// usage arrives in the stream's final chunk, so abandoning the stream
+	// discards the bill for every token the upstream already produced and
+	// the seller already paid for. Settle those at the reservation
+	// estimate rather than zero. The estimate is what the request itself
+	// asked for (its max_tokens, or the configured default), so the buyer
+	// never pays past its own stated ceiling, and a response that produced
+	// no bytes at all still costs nothing.
+	settleAtEstimate := !found && !req.Complete &&
+		len(req.ResponseTail) > 0 &&
+		req.HttpStatus >= 200 && req.HttpStatus < 300
 
 	// Resolve the booked model's rates up front, since the debit is
 	// weighted by direction when the usage split is known. A bundle whose
@@ -509,14 +532,24 @@ func (s *Server) ReportUsage(_ context.Context,
 	}
 
 	// The number of tokens to debit is the prompt/completion sum, or the
-	// total count when the split is absent.
+	// total count when the split is absent. An abandoned stream settles at
+	// the reservation estimate instead.
 	var debitTokens int64
-	if found {
+	switch {
+	case found:
 		debitTokens = counts.totalTokens
 		if counts.hasSplit {
 			debitTokens = counts.promptTokens +
 				counts.completionTokens
 		}
+
+	case settleAtEstimate:
+		debitTokens = release
+		log.Warnf("Incomplete %d response for token %s (path %s) "+
+			"carried %d tail bytes but no usage object; settling "+
+			"at the reserved estimate of %d tokens",
+			req.HttpStatus, req.TokenId, req.Path,
+			len(req.ResponseTail), release)
 	}
 
 	// The bundle was priced at the blended (input+output)/2 rate, but the
@@ -536,16 +569,6 @@ func (s *Server) ReportUsage(_ context.Context,
 			debitTokens = (weightedTimesTwo + rateSum - 1) /
 				rateSum
 		}
-	}
-
-	// Release the exact reservation the authorization took when the proxy
-	// echoed it back, falling back to the configured default estimate for
-	// reports predating the echo. An exact release keeps mismatched
-	// estimates from accumulating into phantom exhaustion on a bundle with
-	// real balance left.
-	release := req.ReservedEstimate
-	if release <= 0 {
-		release = s.cfg.EstimatedTokens
 	}
 
 	after, ok, err := s.store.Debit(req.TokenId, debitTokens, release)
@@ -568,11 +591,12 @@ func (s *Server) ReportUsage(_ context.Context,
 	}
 
 	// The debited amount is priced exactly per direction when the split
-	// is known, and at the blended rate otherwise. Millisatoshis round up
-	// to satoshis.
+	// is known, and at the blended rate otherwise, which covers both a
+	// splitless usage object and an abandoned stream settled at the
+	// estimate. Millisatoshis round up to satoshis.
 	var debitedMsat int64
 	switch {
-	case !found:
+	case !found && !settleAtEstimate:
 
 	case counts.hasSplit:
 		debitedMsat = counts.promptTokens*rates.InputMsatPerToken +

--- a/meterd/server_test.go
+++ b/meterd/server_test.go
@@ -697,3 +697,142 @@ func TestServerReservationEcho(t *testing.T) {
 	require.True(t, authorize().Allowed)
 	require.True(t, authorize().Allowed)
 }
+
+// TestServerSettlesAbandonedStreamAtEstimate verifies that an incomplete,
+// successful streamed response whose tail carries bytes but no usage object
+// is settled at the reservation estimate rather than for free.
+//
+// The usage object arrives in a stream's final chunk, so a client that walks
+// away mid-generation discards it, and with it the bill for every token the
+// upstream already produced. The estimate is what the request itself asked
+// for, so the buyer never pays past its own stated ceiling.
+func TestServerSettlesAbandonedStreamAtEstimate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+
+	// The request below carries no max_tokens, so the reservation falls
+	// back to the configured default estimate; that fallback is exactly
+	// what an abandoned stream settles at, so give it a real value.
+	cfg := testConfig(statePath)
+	cfg.EstimatedTokens = 200
+	client := newTestClient(t, cfg)
+
+	const (
+		path    = "/v1/chat/completions"
+		tokenID = "abandoned-stream-token"
+	)
+	reqText := chatRequestText("gpt-test")
+
+	// Book and authorize a bundle the usual way. The authorization
+	// reserves the default estimate, which is what the abandoned stream
+	// settles at.
+	priceResp, err := client.GetPrice(ctx, &pricesrpc.GetPriceRequest{
+		Path:            path,
+		HttpRequestText: reqText,
+	})
+	require.NoError(t, err)
+
+	_, err = client.ChallengeMinted(ctx, &pricesrpc.ChallengeMintedRequest{
+		Path:            path,
+		HttpRequestText: reqText,
+		TokenId:         tokenID,
+		PriceSats:       priceResp.PriceSats,
+		ServiceName:     "llm",
+	})
+	require.NoError(t, err)
+
+	authResp, err := client.AuthorizeRequest(
+		ctx, &pricesrpc.AuthorizeRequestRequest{
+			Path:            path,
+			HttpRequestText: reqText,
+			TokenId:         tokenID,
+			ServiceName:     "llm",
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, authResp.Allowed)
+
+	// The tail a walked-away stream leaves behind: content chunks, no
+	// usage object, no [DONE].
+	abandonedTail := sseChunk(
+		`{"choices":[{"delta":{"content":"hi"}}],"usage":null}`,
+	) + sseChunk(
+		`{"choices":[{"delta":{"content":" there"}}],"usage":null}`,
+	)
+
+	usageResp, err := client.ReportUsage(ctx, &pricesrpc.ReportUsageRequest{
+		TokenId:          tokenID,
+		Path:             path,
+		ServiceName:      "llm",
+		HttpStatus:       200,
+		ContentType:      sseContentType,
+		Complete:         false,
+		ResponseTail:     []byte(abandonedTail),
+		ReservedEstimate: authResp.ReservedEstimate,
+	})
+	require.NoError(t, err)
+
+	// The settle debits exactly the reservation: at the test rates the
+	// estimate's blended value in sats, and not zero.
+	require.NotZero(t, usageResp.DebitedSats)
+	require.Less(t, usageResp.RemainingSats, priceResp.PriceSats)
+
+	t.Run("no bytes costs nothing", func(t *testing.T) {
+		resp, err := client.ReportUsage(
+			ctx, &pricesrpc.ReportUsageRequest{
+				TokenId:          tokenID,
+				Path:             path,
+				ServiceName:      "llm",
+				HttpStatus:       200,
+				ContentType:      sseContentType,
+				Complete:         false,
+				ResponseTail:     nil,
+				ReservedEstimate: authResp.ReservedEstimate,
+			},
+		)
+		require.NoError(t, err)
+		require.Zero(t, resp.DebitedSats)
+	})
+
+	t.Run("failed response costs nothing", func(t *testing.T) {
+		resp, err := client.ReportUsage(
+			ctx, &pricesrpc.ReportUsageRequest{
+				TokenId:          tokenID,
+				Path:             path,
+				ServiceName:      "llm",
+				HttpStatus:       502,
+				ContentType:      sseContentType,
+				Complete:         false,
+				ResponseTail:     []byte(abandonedTail),
+				ReservedEstimate: authResp.ReservedEstimate,
+			},
+		)
+		require.NoError(t, err)
+		require.Zero(t, resp.DebitedSats)
+	})
+
+	t.Run("complete stream with usage is unaffected", func(t *testing.T) {
+		completeTail := sseChunk(
+			`{"choices":[],"usage":{"prompt_tokens":10,`+
+				`"completion_tokens":10,"total_tokens":20}}`,
+		) + sseChunk(`[DONE]`)
+
+		resp, err := client.ReportUsage(
+			ctx, &pricesrpc.ReportUsageRequest{
+				TokenId:          tokenID,
+				Path:             path,
+				ServiceName:      "llm",
+				HttpStatus:       200,
+				ContentType:      sseContentType,
+				Complete:         true,
+				ResponseTail:     []byte(completeTail),
+				ReservedEstimate: authResp.ReservedEstimate,
+			},
+		)
+		require.NoError(t, err)
+		// 10*1000 + 10*2000 = 30000 msat = 30 sats.
+		require.EqualValues(t, 30, resp.DebitedSats)
+	})
+}

--- a/proxy/metering.go
+++ b/proxy/metering.go
@@ -444,7 +444,7 @@ func mppChargeHashesFromChallengeHeader(header http.Header) []string {
 		return nil
 	}
 
-	var hashes []string
+	hashes := make([]string, 0, len(challenges))
 	for _, challenge := range challenges {
 		if challenge.Intent != mpp.IntentCharge {
 			continue

--- a/proxy/metering.go
+++ b/proxy/metering.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,9 +15,17 @@ import (
 	"time"
 
 	"github.com/lightninglabs/aperture/l402"
+	"github.com/lightninglabs/aperture/mpp"
 	"github.com/lightninglabs/aperture/pricer"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"gopkg.in/macaroon.v2"
 )
+
+// errNoMeteredCredential marks a request that carries no credential the
+// metering pipeline can attribute usage to. Such a request is simply not
+// metered here: it is either unauthenticated, or authenticated under a scheme
+// with its own draw-down accounting, like an MPP session.
+var errNoMeteredCredential = errors.New("no meterable credential on request")
 
 // meteringContextKey is the request context key under which the metering
 // information for an authorized request is stored, so the response modifier
@@ -136,6 +146,78 @@ func l402TokenIDFromAuthHeader(header *http.Header) (string, error) {
 	return identifier.TokenID.String(), nil
 }
 
+// hasPaymentSchemeHeader reports whether the request carries an Authorization
+// header value using the Payment (MPP) scheme. RFC 9110 makes the auth-scheme
+// token case-insensitive, so match it that way.
+func hasPaymentSchemeHeader(header *http.Header) bool {
+	for _, value := range header.Values(l402.HeaderAuthorization) {
+		scheme, _, _ := strings.Cut(value, " ")
+		if strings.EqualFold(scheme, mpp.AuthScheme) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mppChargeTokenIDFromAuthHeader extracts the metering token ID from a
+// Payment charge credential on a request that already passed authentication.
+//
+// The ID is the hex payment hash of the invoice the credential paid, derived
+// from the preimage in the payload. That is the same value the challenge's
+// request carried in methodDetails.paymentHash and the same key the bundle
+// was booked under at mint time, so a charge presented through the Payment
+// door draws down the very bundle its payment purchased. Deriving it from the
+// preimage rather than trusting the echoed request means the ID is backed by
+// the proof of payment itself; the authenticator has already checked the two
+// agree.
+//
+// A session credential yields errNoMeteredCredential: sessions have their own
+// draw-down accounting through the session pricer and must not be double
+// metered here.
+func mppChargeTokenIDFromAuthHeader(header *http.Header) (string, error) {
+	cred, err := mpp.ParseCredential(header)
+	if err != nil {
+		return "", fmt.Errorf("parsing payment credential: %w", err)
+	}
+
+	if cred.Challenge.Intent != mpp.IntentCharge {
+		return "", fmt.Errorf("%w: payment intent %q has its own "+
+			"accounting", errNoMeteredCredential,
+			cred.Challenge.Intent)
+	}
+
+	var payload mpp.ChargePayload
+	if err := json.Unmarshal(cred.Payload, &payload); err != nil {
+		return "", fmt.Errorf("decoding charge payload: %w", err)
+	}
+
+	preimage, err := lntypes.MakePreimageFromStr(payload.Preimage)
+	if err != nil {
+		return "", fmt.Errorf("invalid charge preimage: %w", err)
+	}
+
+	return preimage.Hash().String(), nil
+}
+
+// meteringTokenIDFromAuthHeader resolves the token ID a request's usage is
+// metered under, from whichever credential scheme the request authenticated
+// with. A request that carries no meterable credential at all returns
+// errNoMeteredCredential; a request that carries one that fails to parse
+// returns a hard error, since a malformed credential on a metered service
+// must not silently become free unmetered access.
+func meteringTokenIDFromAuthHeader(header *http.Header) (string, error) {
+	if hasL402SchemeHeader(header) {
+		return l402TokenIDFromAuthHeader(header)
+	}
+
+	if hasPaymentSchemeHeader(header) {
+		return mppChargeTokenIDFromAuthHeader(header)
+	}
+
+	return "", errNoMeteredCredential
+}
+
 // l402TokenIDFromChallengeHeader extracts the L402 token ID from the macaroon
 // embedded in a freshly minted WWW-Authenticate challenge header.
 func l402TokenIDFromChallengeHeader(header http.Header) (string, error) {
@@ -184,30 +266,30 @@ func (p *Proxy) checkMeteredAccess(w http.ResponseWriter, r *http.Request,
 		return r, true
 	}
 
-	// Only requests carrying an L402 token are metered through the
-	// pricer. Requests authenticated through other schemes (for example
-	// MPP sessions) have their own draw-down accounting.
-	tokenID, err := l402TokenIDFromAuthHeader(&r.Header)
-	if err != nil {
-		// A request with no L402-scheme header at all simply is not
-		// metered here and passes through. But a header that does carry
-		// the L402 scheme yet fails to parse must not silently become
-		// free unmetered access on a metered service.
-		if hasL402SchemeHeader(&r.Header) {
-			log.Errorf("Metered request carries an unparseable "+
-				"L402 token: %v", err)
-			sendDirectResponse(
-				w, r, http.StatusInternalServerError,
-				"malformed L402 token",
-			)
-
-			return r, false
-		}
-
-		log.Tracef("Metering skipped, no L402 token on request: %v",
-			err)
+	// Requests carrying an L402 token or a Payment (MPP) charge
+	// credential are metered through the pricer. Requests authenticated
+	// through other schemes (for example MPP sessions) have their own
+	// draw-down accounting.
+	tokenID, err := meteringTokenIDFromAuthHeader(&r.Header)
+	switch {
+	// A request with no meterable credential at all simply is not metered
+	// here and passes through.
+	case errors.Is(err, errNoMeteredCredential):
+		log.Tracef("Metering skipped: %v", err)
 
 		return r, true
+
+	// A header that does carry a meterable scheme yet fails to parse must
+	// not silently become free unmetered access on a metered service.
+	case err != nil:
+		log.Errorf("Metered request carries an unparseable "+
+			"credential: %v", err)
+		sendDirectResponse(
+			w, r, http.StatusInternalServerError,
+			"malformed credential",
+		)
+
+		return r, false
 	}
 
 	result, err := mp.AuthorizeRequest(
@@ -301,7 +383,66 @@ func notifyChallengeMinted(r *http.Request, target *Service,
 			"challenge for token %s: %w", tokenID, err)
 	}
 
+	// The same 402 may also carry Payment (MPP) charge offers, each minted
+	// from its own invoice. Book those too, keyed by the invoice's payment
+	// hash, which is the identity a charge credential proves with its
+	// preimage at request time. Whichever offer the client pays is the
+	// bundle that gets drawn down; the sibling bookings are never
+	// activated and expire unused, which the pricer already handles.
+	for _, hash := range mppChargeHashesFromChallengeHeader(header) {
+		err = mp.ChallengeMinted(r.Context(), r, hash, target.Name,
+			price)
+		if err != nil {
+			return fmt.Errorf("error notifying pricer of minted "+
+				"payment challenge for token %s: %w", hash,
+				err)
+		}
+	}
+
 	return nil
+}
+
+// mppChargeHashesFromChallengeHeader extracts the payment hashes of every
+// well-formed Payment charge offer in a freshly minted WWW-Authenticate
+// header. A header with no Payment offers, which is every header when MPP is
+// disabled, yields an empty slice.
+func mppChargeHashesFromChallengeHeader(header http.Header) []string {
+	challenges, err := mpp.ParseChallengeHeaders(header)
+	if err != nil {
+		// No Payment offer in the header at all.
+		return nil
+	}
+
+	var hashes []string
+	for _, challenge := range challenges {
+		if challenge.Intent != mpp.IntentCharge {
+			continue
+		}
+
+		var chargeReq mpp.ChargeRequest
+		err := mpp.DecodeRequest(challenge.Request, &chargeReq)
+		if err != nil {
+			log.Warnf("Skipping metering booking for undecodable "+
+				"payment charge offer: %v", err)
+			continue
+		}
+
+		// Normalize through lntypes so the booked key is byte for
+		// byte the one the credential's preimage will derive.
+		hash, err := lntypes.MakeHashFromStr(
+			chargeReq.MethodDetails.PaymentHash,
+		)
+		if err != nil {
+			log.Warnf("Skipping metering booking for payment "+
+				"charge offer with invalid payment hash: %v",
+				err)
+			continue
+		}
+
+		hashes = append(hashes, hash.String())
+	}
+
+	return hashes
 }
 
 // attachUsageObserver wraps the response body of a metered request so the

--- a/proxy/metering.go
+++ b/proxy/metering.go
@@ -200,19 +200,50 @@ func mppChargeTokenIDFromAuthHeader(header *http.Header) (string, error) {
 	return preimage.Hash().String(), nil
 }
 
+// hasL402CredentialForm reports whether the request presents an L402
+// credential in any of the forms l402.FromHeader accepts: the Authorization
+// header's L402 or LSAT scheme, or a macaroon carried directly in the
+// Macaroon or Grpc-Metadata-Macaroon header. The presence test has to cover
+// all three, because the authenticator does: a token that authenticates
+// through one of the alternate headers but is invisible to metering would be
+// unlimited unmetered access on a metered service.
+func hasL402CredentialForm(header *http.Header) bool {
+	if hasL402SchemeHeader(header) {
+		return true
+	}
+
+	return header.Get(l402.HeaderMacaroon) != "" ||
+		header.Get(l402.HeaderMacaroonMD) != ""
+}
+
 // meteringTokenIDFromAuthHeader resolves the token ID a request's usage is
 // metered under, from whichever credential scheme the request authenticated
 // with. A request that carries no meterable credential at all returns
-// errNoMeteredCredential; a request that carries one that fails to parse
-// returns a hard error, since a malformed credential on a metered service
-// must not silently become free unmetered access.
+// errNoMeteredCredential; a request whose credential fails to parse returns
+// a hard error, since a malformed credential on a metered service must not
+// silently become free unmetered access.
+//
+// The L402 parse is attempted first and unconditionally, mirroring the
+// authenticator: l402.FromHeader reads the token from the Authorization
+// header or from the Macaroon and Grpc-Metadata-Macaroon headers, so gating
+// the parse on the Authorization scheme alone would let a paid token
+// presented through an alternate header authenticate and then walk past
+// metering. A Payment credential is consulted next, so a request that
+// genuinely authenticated through the Payment door is metered under it even
+// when a stray unparseable L402 header rides along.
 func meteringTokenIDFromAuthHeader(header *http.Header) (string, error) {
-	if hasL402SchemeHeader(header) {
-		return l402TokenIDFromAuthHeader(header)
+	tokenID, l402Err := l402TokenIDFromAuthHeader(header)
+	if l402Err == nil {
+		return tokenID, nil
 	}
 
 	if hasPaymentSchemeHeader(header) {
 		return mppChargeTokenIDFromAuthHeader(header)
+	}
+
+	if hasL402CredentialForm(header) {
+		return "", fmt.Errorf("unparseable L402 credential: %w",
+			l402Err)
 	}
 
 	return "", errNoMeteredCredential

--- a/proxy/metering_test.go
+++ b/proxy/metering_test.go
@@ -13,8 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
+
 	"github.com/lightninglabs/aperture/l402"
+	"github.com/lightninglabs/aperture/mpp"
 	"github.com/lightninglabs/aperture/pricer"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/macaroon.v2"
 )
@@ -693,4 +697,271 @@ func TestAttachUsageObserverReleasesOnProtocolUpgrade(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("no usage report; the reservation leaked")
 	}
+}
+
+// paymentCredentialHeader builds an Authorization: Payment header for a charge
+// credential whose preimage hashes to the returned payment hash. The metering
+// layer runs after authentication, so the credential only has to parse; its
+// HMAC and settlement have already been checked by the time metering sees it.
+func paymentCredentialHeader(t *testing.T, intent string) (http.Header,
+	string) {
+
+	t.Helper()
+
+	var preimage lntypes.Preimage
+	_, err := rand.Read(preimage[:])
+	require.NoError(t, err)
+	paymentHash := preimage.Hash()
+
+	chargeReq := &mpp.ChargeRequest{
+		Amount:   "2000",
+		Currency: mpp.CurrencySat,
+		MethodDetails: mpp.ChargeMethodDetails{
+			Invoice:     "lnbcrt1000n1fake",
+			PaymentHash: paymentHash.String(),
+			Network:     "regtest",
+		},
+	}
+	encodedReq, err := mpp.EncodeRequest(chargeReq)
+	require.NoError(t, err)
+
+	payloadJSON, err := json.Marshal(mpp.ChargePayload{
+		Preimage: preimage.String(),
+	})
+	require.NoError(t, err)
+
+	cred := &mpp.Credential{
+		Challenge: mpp.ChallengeEcho{
+			ID:      "test-challenge-id",
+			Realm:   "test",
+			Method:  mpp.MethodLightning,
+			Intent:  intent,
+			Request: encodedReq,
+		},
+		Payload: json.RawMessage(payloadJSON),
+	}
+	encoded, err := mpp.EncodeCredential(cred)
+	require.NoError(t, err)
+
+	header := make(http.Header)
+	header.Set("Authorization", mpp.AuthScheme+" "+encoded)
+
+	return header, paymentHash.String()
+}
+
+// TestMeteringTokenIDFromPaymentCredential verifies that a Payment charge
+// credential meters under its invoice's payment hash, the same key its mint
+// booking used, and that everything else resolves the way metering expects.
+func TestMeteringTokenIDFromPaymentCredential(t *testing.T) {
+	t.Parallel()
+
+	t.Run("charge meters under the payment hash", func(t *testing.T) {
+		header, wantHash := paymentCredentialHeader(
+			t, mpp.IntentCharge,
+		)
+
+		tokenID, err := meteringTokenIDFromAuthHeader(&header)
+		require.NoError(t, err)
+		require.Equal(t, wantHash, tokenID)
+	})
+
+	t.Run("session is not metered here", func(t *testing.T) {
+		// Sessions have their own draw-down accounting; double
+		// metering a bearer request would charge the buyer twice.
+		header, _ := paymentCredentialHeader(t, mpp.IntentSession)
+
+		_, err := meteringTokenIDFromAuthHeader(&header)
+		require.ErrorIs(t, err, errNoMeteredCredential)
+	})
+
+	t.Run("no credential at all is simply unmetered", func(t *testing.T) {
+		header := make(http.Header)
+
+		_, err := meteringTokenIDFromAuthHeader(&header)
+		require.ErrorIs(t, err, errNoMeteredCredential)
+	})
+
+	t.Run("garbage payment credential is a hard error", func(t *testing.T) {
+		// A malformed credential on a metered service must not become
+		// free unmetered access.
+		header := make(http.Header)
+		header.Set("Authorization", "Payment not-base64url!!!")
+
+		_, err := meteringTokenIDFromAuthHeader(&header)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errNoMeteredCredential)
+	})
+}
+
+// TestCheckMeteredAccessPaymentCharge verifies the metering pipeline admits
+// and annotates a request authenticated with a Payment charge credential,
+// exactly as it does for an L402 token.
+func TestCheckMeteredAccessPaymentCharge(t *testing.T) {
+	t.Parallel()
+
+	header, wantHash := paymentCredentialHeader(t, mpp.IntentCharge)
+
+	newPaymentRequest := func() *http.Request {
+		r := httptest.NewRequest(
+			"POST", "/v1/chat/completions",
+			strings.NewReader(`{"model":"glm"}`),
+		)
+		r.Header.Set(
+			"Authorization", header.Get("Authorization"),
+		)
+
+		return r
+	}
+
+	t.Run("charge request is annotated", func(t *testing.T) {
+		fake := newFakeMeteredPricer()
+		fake.authorizeResult = &pricer.AuthorizeResult{Allowed: true}
+		svc := newMeteredService(fake)
+		p := &Proxy{}
+
+		w := httptest.NewRecorder()
+		r, proceed := p.checkMeteredAccess(
+			w, newPaymentRequest(), svc, "inference",
+		)
+
+		require.True(t, proceed)
+
+		info, ok := r.Context().Value(
+			meteringContextKey{},
+		).(*meteringInfo)
+		require.True(t, ok)
+		require.Equal(t, wantHash, info.tokenID)
+	})
+
+	t.Run("session request passes through unmetered", func(t *testing.T) {
+		sessHeader, _ := paymentCredentialHeader(
+			t, mpp.IntentSession,
+		)
+		fake := newFakeMeteredPricer()
+		svc := newMeteredService(fake)
+		p := &Proxy{}
+
+		r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		r.Header.Set(
+			"Authorization", sessHeader.Get("Authorization"),
+		)
+
+		w := httptest.NewRecorder()
+		annotated, proceed := p.checkMeteredAccess(
+			w, r, svc, "inference",
+		)
+
+		require.True(t, proceed)
+
+		_, ok := annotated.Context().Value(
+			meteringContextKey{},
+		).(*meteringInfo)
+		require.False(t, ok)
+	})
+
+	t.Run("malformed payment credential is refused", func(t *testing.T) {
+		fake := newFakeMeteredPricer()
+		svc := newMeteredService(fake)
+		p := &Proxy{}
+
+		r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		r.Header.Set("Authorization", "Payment not-base64url!!!")
+
+		w := httptest.NewRecorder()
+		_, proceed := p.checkMeteredAccess(w, r, svc, "inference")
+
+		require.False(t, proceed)
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+// TestMPPChargeHashesFromChallengeHeader verifies the mint-side booking key
+// extraction: every well-formed Payment charge offer in a challenge header
+// yields its payment hash, and everything else is skipped.
+func TestMPPChargeHashesFromChallengeHeader(t *testing.T) {
+	t.Parallel()
+
+	var preimage lntypes.Preimage
+	_, err := rand.Read(preimage[:])
+	require.NoError(t, err)
+	paymentHash := preimage.Hash()
+
+	chargeReq := &mpp.ChargeRequest{
+		Amount:   "2000",
+		Currency: mpp.CurrencySat,
+		MethodDetails: mpp.ChargeMethodDetails{
+			Invoice:     "lnbcrt1000n1fake",
+			PaymentHash: paymentHash.String(),
+			Network:     "regtest",
+		},
+	}
+	encodedReq, err := mpp.EncodeRequest(chargeReq)
+	require.NoError(t, err)
+
+	t.Run("charge offer yields its payment hash", func(t *testing.T) {
+		header := make(http.Header)
+		header.Add(
+			"WWW-Authenticate",
+			`L402 macaroon="AGIAJEemVQUTEyNCR0exk7ek90Cg==", `+
+				`invoice="lnbcrt1fake"`,
+		)
+		mpp.SetChallengeHeader(header, &mpp.ChallengeParams{
+			ID:      "chal-id",
+			Realm:   "test",
+			Method:  mpp.MethodLightning,
+			Intent:  mpp.IntentCharge,
+			Request: encodedReq,
+		})
+
+		hashes := mppChargeHashesFromChallengeHeader(header)
+		require.Equal(t, []string{paymentHash.String()}, hashes)
+	})
+
+	t.Run("session offers are skipped", func(t *testing.T) {
+		header := make(http.Header)
+		mpp.SetChallengeHeader(header, &mpp.ChallengeParams{
+			ID:      "chal-id",
+			Realm:   "test",
+			Method:  mpp.MethodLightning,
+			Intent:  mpp.IntentSession,
+			Request: encodedReq,
+		})
+
+		require.Empty(t, mppChargeHashesFromChallengeHeader(header))
+	})
+
+	t.Run("no payment offer yields no hashes", func(t *testing.T) {
+		header := make(http.Header)
+		header.Add(
+			"WWW-Authenticate",
+			`L402 macaroon="AGIAJEemVQUTEyNCR0exk7ek90Cg==", `+
+				`invoice="lnbcrt1fake"`,
+		)
+
+		require.Empty(t, mppChargeHashesFromChallengeHeader(header))
+	})
+
+	t.Run("offer with a bad hash is skipped", func(t *testing.T) {
+		badReq, err := mpp.EncodeRequest(&mpp.ChargeRequest{
+			Amount:   "2000",
+			Currency: mpp.CurrencySat,
+			MethodDetails: mpp.ChargeMethodDetails{
+				Invoice:     "lnbcrt1fake",
+				PaymentHash: "not-a-hash",
+				Network:     "regtest",
+			},
+		})
+		require.NoError(t, err)
+
+		header := make(http.Header)
+		mpp.SetChallengeHeader(header, &mpp.ChallengeParams{
+			ID:      "chal-id",
+			Realm:   "test",
+			Method:  mpp.MethodLightning,
+			Intent:  mpp.IntentCharge,
+			Request: badReq,
+		})
+
+		require.Empty(t, mppChargeHashesFromChallengeHeader(header))
+	})
 }

--- a/proxy/metering_test.go
+++ b/proxy/metering_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -964,4 +965,69 @@ func TestMPPChargeHashesFromChallengeHeader(t *testing.T) {
 
 		require.Empty(t, mppChargeHashesFromChallengeHeader(header))
 	})
+}
+
+// TestMeteringSeesEveryL402HeaderForm pins the presence test to the same
+// three header forms the authenticator reads. A paid token presented through
+// the Macaroon or Grpc-Metadata-Macaroon header authenticates exactly like
+// one in the Authorization header, so it must meter exactly like one too;
+// gating metering on the Authorization scheme alone turned the alternate
+// headers into unlimited unmetered access on a metered service.
+func TestMeteringSeesEveryL402HeaderForm(t *testing.T) {
+	t.Parallel()
+
+	// The alternate headers carry the macaroon hex-encoded with the
+	// preimage as a caveat, unlike the Authorization form's base64 plus
+	// separate preimage.
+	mac, tokenID := newTestMacaroon(t)
+
+	var preimage lntypes.Preimage
+	_, err := rand.Read(preimage[:])
+	require.NoError(t, err)
+	require.NoError(t, mac.AddFirstPartyCaveat(
+		[]byte("preimage="+preimage.String()),
+	))
+
+	macBytes, err := mac.MarshalBinary()
+	require.NoError(t, err)
+	macHex := hex.EncodeToString(macBytes)
+
+	for _, headerName := range []string{
+		"Macaroon", "Grpc-Metadata-Macaroon",
+	} {
+		t.Run(headerName, func(t *testing.T) {
+			header := make(http.Header)
+			header.Set(headerName, macHex)
+
+			got, err := meteringTokenIDFromAuthHeader(&header)
+			require.NoError(t, err)
+			require.Equal(t, tokenID, got)
+		})
+	}
+
+	t.Run("garbage in an alternate header is a hard error", func(t *testing.T) {
+		// A credential-shaped header that fails to parse must refuse
+		// the request rather than skip metering.
+		header := make(http.Header)
+		header.Set("Macaroon", "not-a-macaroon")
+
+		_, err := meteringTokenIDFromAuthHeader(&header)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errNoMeteredCredential)
+	})
+
+	t.Run("a payment credential meters despite a junk L402 header",
+		func(t *testing.T) {
+			// The request authenticated through the Payment door; a
+			// stray unparseable L402 value riding along must not
+			// turn a metered request into a refusal.
+			credHeader, hash := paymentCredentialHeader(
+				t, mpp.IntentCharge,
+			)
+			credHeader.Set("Macaroon", "not-a-macaroon")
+
+			got, err := meteringTokenIDFromAuthHeader(&credHeader)
+			require.NoError(t, err)
+			require.Equal(t, hash, got)
+		})
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -96,6 +96,108 @@ type Proxy struct {
 	authenticator auth.Authenticator
 	services      []*Service
 	blocklist     map[string]struct{}
+
+	// writeDeadlineWindow, when non-zero, converts the server's absolute
+	// write timeout into a rolling idle deadline for proxied responses:
+	// each write to the client pushes the connection's write deadline this
+	// far into the future. Without it, http.Server.WriteTimeout is a
+	// single deadline armed when the response begins, and any streamed
+	// response outliving it, an SSE inference stream being the canonical
+	// case, is cut off mid-body no matter how healthily it is flowing.
+	// With it, the timeout means what an operator almost certainly
+	// intended: a stream dies when it stalls, not when it lasts.
+	writeDeadlineWindow time.Duration
+}
+
+// SetWriteDeadlineWindow installs the rolling write deadline window applied
+// to proxied responses. Pass the server's configured write timeout; zero
+// disables the rolling extension and leaves whatever absolute deadline the
+// server armed.
+func (p *Proxy) SetWriteDeadlineWindow(window time.Duration) {
+	p.writeDeadlineWindow = window
+}
+
+// deadlineBumpingWriter wraps a ResponseWriter so every write pushes the
+// connection's write deadline forward by a fixed window. Unwrap keeps
+// http.ResponseController able to reach the underlying writer's Flusher and
+// deadline hooks, which the reverse proxy relies on for streaming.
+type deadlineBumpingWriter struct {
+	http.ResponseWriter
+
+	// controller reaches the connection's deadline hooks through however
+	// many wrappers sit between here and the real writer.
+	controller *http.ResponseController
+
+	// window is how far each write pushes the deadline into the future.
+	window time.Duration
+
+	// lastBump is when the deadline was last pushed, so the syscall runs
+	// at most every quarter window rather than on every chunk.
+	lastBump time.Time
+
+	// unsupported latches once the underlying connection reports it has
+	// no deadline support, so the error is not re-made on every write.
+	unsupported bool
+}
+
+// bump pushes the write deadline forward, but only while the stream is
+// healthy: a gap since the last write that is shorter than the window earns
+// an extension, and one that exceeds the window does not.
+//
+// The second half is what makes the timeout still mean something. A write's
+// bytes land in the server's buffer without touching the socket, so the
+// deadline is only ever enforced by the flush that follows, and the flush
+// runs after the write. If a write after a long stall could re-arm the
+// deadline, its own flush would find a fresh deadline and succeed, and no
+// stall would ever be caught. Refusing the extension leaves the expired
+// deadline in force, and the flush tears the connection down exactly as the
+// timeout promises.
+func (d *deadlineBumpingWriter) bump() {
+	if d.unsupported {
+		return
+	}
+
+	now := time.Now()
+	if !d.lastBump.IsZero() {
+		sinceLast := now.Sub(d.lastBump)
+
+		// Recently armed: the deadline still holds most of the
+		// window, so spare the syscall.
+		if sinceLast < d.window/4 {
+			return
+		}
+
+		// Stalled past the window: the armed deadline has already
+		// expired, and it stays expired so the flush that follows
+		// this write refuses it.
+		if sinceLast >= d.window {
+			return
+		}
+	}
+
+	if err := d.controller.SetWriteDeadline(now.Add(d.window)); err != nil {
+		// A connection without deadline support gets the server's
+		// absolute timeout behavior, the same as before this wrapper
+		// existed.
+		d.unsupported = true
+		return
+	}
+	d.lastBump = now
+}
+
+func (d *deadlineBumpingWriter) WriteHeader(statusCode int) {
+	d.bump()
+	d.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (d *deadlineBumpingWriter) Write(b []byte) (int, error) {
+	d.bump()
+	return d.ResponseWriter.Write(b)
+}
+
+// Unwrap exposes the wrapped writer to http.ResponseController.
+func (d *deadlineBumpingWriter) Unwrap() http.ResponseWriter {
+	return d.ResponseWriter
 }
 
 // rewriteRequestPath rewrites the request path according to service config.
@@ -189,6 +291,17 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// header to application/grpc.
 	if strings.HasPrefix(r.Header.Get(hdrContentType), hdrTypeGrpc) {
 		w.Header().Set(hdrContentType, hdrTypeGrpc)
+	}
+
+	// Roll the write deadline forward as the response flows, so a healthy
+	// long-lived stream is not cut off by the server's absolute write
+	// timeout while a stalled one still dies.
+	if p.writeDeadlineWindow > 0 {
+		w = &deadlineBumpingWriter{
+			ResponseWriter: w,
+			controller:     http.NewResponseController(w),
+			window:         p.writeDeadlineWindow,
+		}
 	}
 
 	// Priority local services are checked before proxy service matching

--- a/proxy/streaming_test.go
+++ b/proxy/streaming_test.go
@@ -1,0 +1,260 @@
+package proxy_test
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/aperture/auth"
+	"github.com/lightninglabs/aperture/proxy"
+	"github.com/stretchr/testify/require"
+)
+
+// newStreamingProxy stands up a proxy in front of the given backend handler
+// and returns the proxy's base URL. The service has auth off, since what
+// these tests exercise is the byte path of the response, not the payment for
+// it.
+func newStreamingProxy(t *testing.T, backend http.Handler,
+	configure func(*proxy.Proxy),
+	serverTweak func(*httptest.Server)) string {
+
+	t.Helper()
+
+	backendServer := httptest.NewServer(backend)
+	t.Cleanup(backendServer.Close)
+
+	backendURL, err := url.Parse(backendServer.URL)
+	require.NoError(t, err)
+
+	services := []*proxy.Service{{
+		Address:    backendURL.Host,
+		HostRegexp: ".*",
+		PathRegexp: "^/stream.*$",
+		Protocol:   "http",
+		Auth:       "off",
+	}}
+
+	p, err := proxy.New(
+		auth.NewMockAuthenticator(), services, []string{}, nil,
+	)
+	require.NoError(t, err)
+
+	if configure != nil {
+		configure(p)
+	}
+
+	proxyServer := httptest.NewUnstartedServer(
+		http.HandlerFunc(p.ServeHTTP),
+	)
+	if serverTweak != nil {
+		serverTweak(proxyServer)
+	}
+	proxyServer.Start()
+	t.Cleanup(proxyServer.Close)
+
+	return proxyServer.URL
+}
+
+// TestProxyStreamsResponseIncrementally proves the flush guarantee end to
+// end: a chunk written by the backend reaches the client while the backend is
+// still holding the response open. A proxy that buffered the body would
+// deadlock this test, since the backend refuses to finish until the client
+// has seen the first chunk.
+func TestProxyStreamsResponseIncrementally(t *testing.T) {
+	t.Parallel()
+
+	firstChunkSeen := make(chan struct{})
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, "data: first\n\n")
+		w.(http.Flusher).Flush()
+
+		// Refuse to finish the response until the client has read the
+		// first chunk through the proxy.
+		select {
+		case <-firstChunkSeen:
+		case <-time.After(5 * time.Second):
+			t.Error("client never saw the first chunk; the " +
+				"proxy is buffering the response")
+			return
+		}
+
+		fmt.Fprint(w, "data: second\n\n")
+	})
+
+	baseURL := newStreamingProxy(t, backend, nil, nil)
+
+	resp, err := http.Get(baseURL + "/stream")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	reader := bufio.NewReader(resp.Body)
+
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "data: first\n", line)
+	close(firstChunkSeen)
+
+	rest, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Contains(t, string(rest), "data: second")
+}
+
+// TestProxyRollsWriteDeadlineForStreams proves that a healthy stream outlives
+// the server's absolute write timeout when the rolling window is installed,
+// and is killed by it when it is not.
+//
+// The server's WriteTimeout is a single deadline armed as the response
+// begins; a streamed generation routinely outlives any sane value of it while
+// writing the whole way through. The proxy's rolling window pushes the
+// deadline forward on every write, turning the timeout into what it should
+// have meant all along: a stall killer.
+func TestProxyRollsWriteDeadlineForStreams(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writeTimeout = 400 * time.Millisecond
+		chunks       = 6
+		chunkGap     = 150 * time.Millisecond
+	)
+
+	// The stream lasts chunks*chunkGap = 900ms, more than twice the write
+	// timeout, while never pausing longer than chunkGap between writes.
+	backend := http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		for i := 0; i < chunks; i++ {
+			time.Sleep(chunkGap)
+			fmt.Fprintf(w, "data: chunk-%d\n\n", i)
+			w.(http.Flusher).Flush()
+		}
+	})
+
+	readAll := func(baseURL string) (string, error) {
+		resp, err := http.Get(baseURL + "/stream")
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, err := io.ReadAll(resp.Body)
+		return string(body), err
+	}
+
+	t.Run("rolling window carries the stream", func(t *testing.T) {
+		t.Parallel()
+
+		baseURL := newStreamingProxy(
+			t, backend,
+			func(p *proxy.Proxy) {
+				p.SetWriteDeadlineWindow(writeTimeout)
+			},
+			func(s *httptest.Server) {
+				s.Config.WriteTimeout = writeTimeout
+			},
+		)
+
+		body, err := readAll(baseURL)
+		require.NoError(t, err)
+		for i := 0; i < chunks; i++ {
+			require.Contains(
+				t, body, fmt.Sprintf("chunk-%d", i),
+			)
+		}
+	})
+
+	t.Run("absolute deadline kills the same stream", func(t *testing.T) {
+		t.Parallel()
+
+		// The control: the identical stream against the identical
+		// server, without the rolling window. If this passed, the
+		// test above would be proving nothing.
+		baseURL := newStreamingProxy(
+			t, backend, nil,
+			func(s *httptest.Server) {
+				s.Config.WriteTimeout = writeTimeout
+			},
+		)
+
+		body, err := readAll(baseURL)
+		if err == nil {
+			require.NotContains(
+				t, body,
+				fmt.Sprintf("chunk-%d", chunks-1),
+				"stream survived the absolute write "+
+					"deadline; the control is not "+
+					"controlling",
+			)
+		}
+	})
+}
+
+// TestProxyStreamKilledWhenStalled proves the rolling window still kills a
+// genuinely stalled stream: the deadline only moves when bytes move, so a
+// backend that stops writing for longer than the window tears the connection
+// down rather than pinning it open forever.
+func TestProxyStreamKilledWhenStalled(t *testing.T) {
+	t.Parallel()
+
+	const writeTimeout = 300 * time.Millisecond
+
+	backendDone := make(chan struct{})
+	backend := http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+
+		defer close(backendDone)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, "data: alive\n\n")
+		w.(http.Flusher).Flush()
+
+		// Stall far past the window, then try to write again. The
+		// connection's deadline has passed, so this write cannot
+		// reach the client.
+		time.Sleep(4 * writeTimeout)
+		fmt.Fprint(w, "data: too-late\n\n")
+	})
+
+	baseURL := newStreamingProxy(
+		t, backend,
+		func(p *proxy.Proxy) {
+			p.SetWriteDeadlineWindow(writeTimeout)
+		},
+		func(s *httptest.Server) {
+			s.Config.WriteTimeout = writeTimeout
+		},
+	)
+
+	resp, err := http.Get(baseURL + "/stream")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.True(
+		t, err != nil || !strings.Contains(string(body), "too-late"),
+		"a stalled stream outlived the write deadline window",
+	)
+
+	select {
+	case <-backendDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler never finished")
+	}
+}


### PR DESCRIPTION
In this PR, we make streamed inference responses first-class through the whole metered pipeline. The SSE byte path itself was already right, the proxy flushes per write and meterd parses the final usage chunk of a stream, but three things around it were not, and each one surfaced while running a live MPP buyer against a metered signet deployment.

## Payment (MPP) charge requests were never metered

The metering pipeline joins mint-time bookings to request-time draw-downs through the L402 macaroon's token ID, an identity only the L402 door can present. The Payment offer in the same 402 mints its own invoice, so an MPP buyer's bundle was booked under a key its credential could never produce: the bundle sat untouched at full balance while the buyer consumed the service, request after request, unmetered. The join key for a charge is now the invoice's payment hash, booked from the challenge header at mint time and derived from the credential's preimage at request time, so the ID is backed by the proof of payment itself.

This composes with a deliberate policy change: on metered services, charge credentials are re-presentable rather than single use. A metered payment buys a bundle whose draw-down is the spend, so consuming the credential on first use would strand everything past one request; the pricer refusing an exhausted bundle is what ends the credential's useful life, exactly as it does for an L402 token on the same service. The strict single-use rule stands everywhere else.

## The write timeout killed healthy streams

`http.Server.WriteTimeout` is one absolute deadline armed as the response begins, so any generation outliving it (30s in the shipped config) was cut off mid-stream no matter how steadily it was flowing. The proxy now rolls the connection's write deadline forward on each write, refusing the extension once the gap since the last write exceeds the window, so the timeout kills stalls rather than length. The refusal half matters: bytes land in the server's buffer without touching the socket, so the deadline is only enforced by the flush after a write, and a post-stall write that could re-arm the deadline would never be caught. The new streaming tests pin all three properties against a real server: incremental delivery, survival past the absolute deadline, and death on stall.

## An abandoned stream was free inference

The usage object arrives in a stream's final chunk, so a client that disconnects mid-generation discards it; the report then found nothing to bill, released the reservation, and debited zero while the seller ate the upstream cost. An incomplete successful response whose tail carries bytes but no usage object now settles at the reservation estimate, which is the ceiling the request itself stated via max_tokens, matching what the session path already did. No bytes, or a failed response, still costs nothing.

The two pre-existing test failures on master (`TestProxyMPPChargeEndToEnd`, `lnc`) reproduce identically on this branch's base and are untouched here.

See each commit message for a detailed description w.r.t the incremental changes.
