### PR TITLE
auth: dispatch MPP receipts by credential intent

### DIFF
--- a/auth/mpp_authenticator.go
+++ b/auth/mpp_authenticator.go
@@ -486,6 +486,17 @@ func (a *MPPAuthenticator) ReceiptHeader(header *http.Header,
 		return nil
 	}
 
+	// Only produce receipts for charge credentials. A session credential
+	// parses fine here too (its request JSON simply has no methodDetails),
+	// so without this guard we would emit a receipt with an empty
+	// reference and the multi authenticator would never reach the session
+	// provider that knows the real one.
+	if cred.Challenge.Method != mpp.MethodLightning ||
+		cred.Challenge.Intent != mpp.IntentCharge {
+
+		return nil
+	}
+
 	var chargeReq mpp.ChargeRequest
 	if err := mpp.DecodeRequest(
 		cred.Challenge.Request, &chargeReq,

--- a/auth/mpp_authenticator_test.go
+++ b/auth/mpp_authenticator_test.go
@@ -892,3 +892,25 @@ func TestMPPAuthenticatorNilReusablePolicyStaysStrict(t *testing.T) {
 	require.True(t, auth.Accept(&h, "metered-service"))
 	require.False(t, auth.Accept(&h, "metered-service"))
 }
+
+// TestMPPAuthenticatorReceiptWrongIntent verifies that the charge
+// authenticator declines to produce a receipt for a session credential rather
+// than misreading the session request as a charge request and emitting a
+// receipt with an empty reference.
+func TestMPPAuthenticatorReceiptWrongIntent(t *testing.T) {
+	auth, _ := newTestChargeAuth(
+		t, &mockChallenger{}, newMockInvoiceChecker(),
+	)
+	preimage, paymentHash := testPreimageAndHash(t)
+
+	challenge, _ := buildSessionChallenge(
+		t, testHMACSecret, paymentHash, 300,
+	)
+	h := buildSessionCredential(t, challenge, &mpp.SessionPayload{
+		Action:        mpp.SessionActionOpen,
+		Preimage:      hex.EncodeToString(preimage[:]),
+		ReturnInvoice: testReturnInvoice(t, paymentHash),
+	})
+
+	require.Nil(t, auth.ReceiptHeader(&h, "test-service"))
+}

--- a/auth/mpp_session_authenticator.go
+++ b/auth/mpp_session_authenticator.go
@@ -827,6 +827,15 @@ func (a *MPPSessionAuthenticator) ReceiptHeader(header *http.Header,
 		return nil
 	}
 
+	// Only produce receipts for session credentials, mirroring the guard
+	// in Accept. A charge credential would otherwise decode into an empty
+	// session payload and yield a receipt with no reference.
+	if cred.Challenge.Method != mpp.MethodLightning ||
+		cred.Challenge.Intent != mpp.IntentSession {
+
+		return nil
+	}
+
 	var payload mpp.SessionPayload
 	if err := json.Unmarshal(cred.Payload, &payload); err != nil {
 		return nil

--- a/auth/mpp_session_authenticator_test.go
+++ b/auth/mpp_session_authenticator_test.go
@@ -973,3 +973,88 @@ func TestSessionTopUpCannotOpenSecondSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(500), session.DepositSats)
 }
+
+// TestSessionOpenReceiptReference verifies that the receipt for an open
+// credential carries the deposit payment hash as its reference, which is the
+// session ID every later bearer and close will name.
+func TestSessionOpenReceiptReference(t *testing.T) {
+	auth, _, _, hmacSecret := newTestSessionAuth(t)
+	preimage, paymentHash := testPreimageAndHash(t)
+
+	challenge, sessionID := buildSessionChallenge(
+		t, hmacSecret, paymentHash, 300,
+	)
+	h := buildSessionCredential(t, challenge, &mpp.SessionPayload{
+		Action:        mpp.SessionActionOpen,
+		Preimage:      hex.EncodeToString(preimage[:]),
+		ReturnInvoice: testReturnInvoice(t, paymentHash),
+	})
+
+	receiptHdr := auth.ReceiptHeader(&h, "test-service")
+	require.NotNil(t, receiptHdr)
+
+	receipt, err := mpp.ParseReceiptHeader(receiptHdr)
+	require.NoError(t, err)
+	require.Equal(t, sessionID, receipt.Reference)
+	require.Equal(t, challenge.ID, receipt.ChallengeID)
+}
+
+// TestSessionReceiptWrongIntent verifies that the session authenticator
+// declines to produce a receipt for a charge credential, leaving it for the
+// charge authenticator instead of emitting a receipt with no reference.
+func TestSessionReceiptWrongIntent(t *testing.T) {
+	auth, _, _, _ := newTestSessionAuth(t)
+	preimage, paymentHash := testPreimageAndHash(t)
+
+	challenge := testChargeChallenge(t, paymentHash, testExpiry())
+	h := buildTestCredential(t, challenge, preimage)
+
+	require.Nil(t, auth.ReceiptHeader(&h, "test-service"))
+}
+
+// TestMultiAuthReceiptIntentDispatch reproduces the live bug where the multi
+// authenticator asked the charge authenticator for a receipt on a session
+// credential: the charge side parsed the session request as a charge request,
+// found no methodDetails, and emitted a receipt with an empty reference before
+// the session authenticator was ever consulted. With intent discrimination in
+// both providers, the open receipt must carry the deposit payment hash.
+func TestMultiAuthReceiptIntentDispatch(t *testing.T) {
+	chargeAuth, _ := newTestChargeAuth(
+		t, &mockChallenger{}, newMockInvoiceChecker(),
+	)
+	sessAuth, _, _, hmacSecret := newTestSessionAuth(t)
+	multi := NewMultiAuthenticator(chargeAuth, sessAuth)
+
+	preimage, paymentHash := testPreimageAndHash(t)
+	challenge, sessionID := buildSessionChallenge(
+		t, hmacSecret, paymentHash, 300,
+	)
+	h := buildSessionCredential(t, challenge, &mpp.SessionPayload{
+		Action:        mpp.SessionActionOpen,
+		Preimage:      hex.EncodeToString(preimage[:]),
+		ReturnInvoice: testReturnInvoice(t, paymentHash),
+	})
+
+	receiptHdr := multi.ReceiptHeader(&h, "test-service")
+	require.NotNil(t, receiptHdr)
+
+	receipt, err := mpp.ParseReceiptHeader(receiptHdr)
+	require.NoError(t, err)
+	require.Equal(t, sessionID, receipt.Reference)
+
+	// The reverse direction must hold too: a charge credential through the
+	// same multi authenticator gets the charge receipt, whichever order
+	// the providers are consulted in.
+	sessFirst := NewMultiAuthenticator(sessAuth, chargeAuth)
+	chargeChallenge := testChargeChallenge(t, paymentHash, testExpiry())
+	chargeH := buildTestCredential(t, chargeChallenge, preimage)
+
+	chargeReceiptHdr := sessFirst.ReceiptHeader(&chargeH, "test-service")
+	require.NotNil(t, chargeReceiptHdr)
+
+	chargeReceipt, err := mpp.ParseReceiptHeader(chargeReceiptHdr)
+	require.NoError(t, err)
+	require.Equal(
+		t, hex.EncodeToString(paymentHash[:]), chargeReceipt.Reference,
+	)
+}


### PR DESCRIPTION
In this PR, we fix the `Payment-Receipt` header for MPP session credentials. The multi authenticator returns the first non-nil receipt from its providers, and the charge authenticator is consulted before the session one. For a session open credential, the charge side's `ReceiptHeader` parsed the credential fine, decoded the session request into a `ChargeRequest` (JSON just ignores the unknown fields, and there is no `methodDetails` object to be found), and emitted a receipt with an empty `reference`. The session authenticator, which would have stamped the deposit payment hash, was never asked.

We caught this live on a regtest run of the pi-402 session flow: the server accepted the open and the wire showed

```
Payment-Receipt: {"status":"success","method":"lightning","timestamp":"2026-08-13T06:22:37Z","reference":"","challengeId":"e6RWJf..."}
```

which a conformant client discards (`mpp: receipt missing reference`), so the buyer lost its proof of payment for the deposit.

The fix mirrors the intent guard that `Accept` already has into both `ReceiptHeader` implementations: the charge provider only answers lightning/charge credentials and the session provider only answers lightning/session, so the multi authenticator falls through to whichever provider actually handles the credential. `TestMultiAuthReceiptIntentDispatch` pins the dispatch in both provider orderings, and each provider gets a wrong-intent decline test.