### PR TITLE
docs: describe metering and the Payment scheme in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,51 @@ services and APIs.
 
 [l402]: https://github.com/lightninglabs/L402
 
+## Payment schemes
+
+Aperture speaks two payment protocols, and a single `402` response can carry an
+offer for each so the buyer takes whichever door it understands.
+
+**L402** is the default and is described above: a macaroon plus the preimage of
+the invoice that paid for it.
+
+**The Payment HTTP Authentication Scheme** ([`draft-httpauth-payment-00`][mpp],
+co-authored by Stripe and Tempo) is enabled with
+`--authenticator.enablempp`. It supports two intents. A *charge* buys a single
+request, and a *session* (`--authenticator.enablesessions`) holds a deposit that
+many requests draw against, refunding whatever is left when the buyer closes it.
+Sessions and charge consumption records both need a real database, so `--dbbackend`
+must be `sqlite` or `postgres`; etcd is refused at startup.
+
+[mpp]: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+
+## Metered pricing
+
+Aperture can sell one request per payment, or it can sell a prepaid bundle of
+usage and draw it down as requests flow. The second mode exists because a fixed
+price per request is the wrong unit for LLM inference: one completion costs the
+seller a few dozen upstream tokens and the next costs four thousand, and the
+seller only learns which after the response has been served.
+
+Metering splits the two apart. The payment happens once, up front, for a bundle
+at a known price. The accounting happens per request, after the fact, from the
+usage the upstream actually reported. Aperture holds no pricing or balance state
+of its own; it calls out to a price server over gRPC (`pricesrpc`), configured
+per service with `dynamicprice` and `metered: true`. The reference price server,
+`meterd`, ships in this repo and keeps its state in a JSON file, which is enough
+for development. Production deployments embed `meterd.Server` behind their own
+`Store` and `RateSource`.
+
+Streamed responses work the same way: aperture keeps a bounded tail of the
+response so it can read the usage out of the final SSE chunk, and applies
+`writetimeout` as a rolling idle window rather than an absolute deadline so a
+generation lives as long as it keeps flowing. Size that window to the worst
+gap between chunks, not to the total length of the stream.
+
+[`docs/metering.md`](docs/metering.md) covers all of this in full: the bundle
+lifecycle, how L402 and each Payment intent attribute usage to a balance, what
+changes under streaming, and the configuration reference.
+
 ## Installation / Setup
 
 **lnd**


### PR DESCRIPTION
In this PR, we fix the README, which still describes an aperture that only sells one request per payment over L402. Master has done considerably more than that for months and the front door mentions none of it: `git grep -i 'metering\|meterd\|MPP' README.md` on master returns nothing.

Two sections go in.

The first covers the Payment HTTP Authentication Scheme running alongside L402, with both intents (charge and session), and states plainly that `--authenticator.enablempp` needs sqlite or postgres because etcd cannot record spent charges and is refused at startup. Existing etcd deployments hit that as a failed boot today, which is a bad way to learn about a migration.

The second covers metered pricing: why a fixed price per request is the wrong unit for inference, the split between paying once for a bundle and accounting per request from the upstream's reported usage, and the `pricesrpc` seam with `meterd` as the reference implementation. It also carries over the `writetimeout` note, since a rolling idle window sized to total stream length rather than to the worst gap between chunks will cut off a reasoning model mid-thought.

Both sections point at [`docs/metering.md`](https://github.com/lightninglabs/aperture/blob/master/docs/metering.md), which has been the only documentation of the entire feature and was linked from nowhere.

Docs only, no code changes. This is worth landing before the next tag, since v0.5.0 predates all of this work and the release notes will point readers at a README that does not mention it.