### PR TITLE
l402: allow concurrent authenticated calls

### DIFF
--- a/l402/client_interceptor.go
+++ b/l402/client_interceptor.go
@@ -79,14 +79,20 @@ var (
 // ClientInterceptor is a gRPC client interceptor that can handle L402
 // authentication challenges with embedded payment requests. It uses a
 // connection to lnd to automatically pay for an authentication token.
+// A ClientInterceptor is safe for concurrent use. It serializes token
+// acquisition while allowing calls with a paid token to run concurrently.
 type ClientInterceptor struct {
 	lnd           *lndclient.LndServices
 	store         Store
 	callTimeout   time.Duration
 	maxCost       btcutil.Amount
 	maxFee        btcutil.Amount
-	lock          sync.Mutex
 	allowInsecure bool
+
+	// paymentLock serializes this interceptor's token store access
+	// and token acquisition. Calls with a paid token release it before
+	// invoking the transport.
+	paymentLock sync.Mutex
 }
 
 // NewInterceptor creates a new gRPC client interceptor that uses the provided
@@ -126,40 +132,12 @@ func (i *ClientInterceptor) UnaryInterceptor(ctx context.Context, method string,
 	req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption) error {
 
-	// To avoid paying for a token twice if two parallel requests are
-	// happening, we require an exclusive lock here.
-	i.lock.Lock()
-	defer i.lock.Unlock()
+	return i.intercept(ctx, opts, func(opts ...grpc.CallOption) error {
+		rpcCtx, cancel := context.WithTimeout(ctx, i.callTimeout)
+		defer cancel()
 
-	// Create the context that we'll use to initiate the real request. This
-	// contains the means to extract response headers and possibly also an
-	// auth token, if we already have paid for one.
-	iCtx, err := i.newInterceptContext(ctx, opts)
-	if err != nil {
-		return err
-	}
-
-	// Try executing the call now. If anything goes wrong, we only handle
-	// the L402 error message that comes in the form of a gRPC status error.
-	rpcCtx, cancel := context.WithTimeout(ctx, i.callTimeout)
-	defer cancel()
-	err = invoker(rpcCtx, method, req, reply, cc, iCtx.opts...)
-	if !IsPaymentRequired(err) {
-		return err
-	}
-
-	// Find out if we need to pay for a new token or perhaps resume
-	// a previously aborted payment.
-	err = i.handlePayment(iCtx)
-	if err != nil {
-		return err
-	}
-
-	// Execute the same request again, now with the L402
-	// token added as an RPC credential.
-	rpcCtx2, cancel2 := context.WithTimeout(ctx, i.callTimeout)
-	defer cancel2()
-	return invoker(rpcCtx2, method, req, reply, cc, iCtx.opts...)
+		return invoker(rpcCtx, method, req, reply, cc, opts...)
+	})
 }
 
 // StreamInterceptor is an interceptor method that can be used directly by gRPC
@@ -174,49 +152,120 @@ func (i *ClientInterceptor) StreamInterceptor(ctx context.Context,
 	streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream,
 	error) {
 
-	// To avoid paying for a token twice if two parallel requests are
-	// happening, we require an exclusive lock here.
-	i.lock.Lock()
-	defer i.lock.Unlock()
+	var stream grpc.ClientStream
+	err := i.intercept(ctx, opts, func(opts ...grpc.CallOption) error {
+		// A stream uses ctx for its entire lifetime. Applying
+		// callTimeout here would cancel it as soon as the interceptor
+		// returns.
+		var err error
+		stream, err = streamer(ctx, desc, cc, method, opts...)
 
-	// Create the context that we'll use to initiate the real request. This
-	// contains the means to extract response headers and possibly also an
-	// auth token, if we already have paid for one.
-	iCtx, err := i.newInterceptContext(ctx, opts)
+		return err
+	})
 	if err != nil {
+		// A stream from an unsuccessful attempt isn't usable. In
+		// particular, don't return one retained before payment handling
+		// failed.
 		return nil, err
 	}
 
-	// Try establishing the stream now. If anything goes wrong, we only
-	// handle the L402 error message that comes in the form of a gRPC status
-	// error. The context of a stream will be used for the whole lifetime of
-	// it, so we can't really clamp down on the initial call with a timeout.
-	stream, err := streamer(ctx, desc, cc, method, iCtx.opts...)
-	if !IsPaymentRequired(err) {
-		return stream, err
+	return stream, nil
+}
+
+// intercept adds L402 authentication to a transport call. Calls with a paid
+// token run concurrently, while calls without one remain serialized until a
+// single payment attempt finishes.
+func (i *ClientInterceptor) intercept(ctx context.Context,
+	opts []grpc.CallOption, invoke func(...grpc.CallOption) error) error {
+
+	var (
+		iCtx           *interceptContext
+		callOutside    bool
+		paymentHandled bool
+	)
+
+	// Keep the first unauthenticated call under the payment lock. Once that
+	// call pays, queued calls load its token instead of requesting fresh
+	// challenges of their own.
+	err := i.withPaymentLock(func() error {
+		var err error
+		iCtx, err = i.newInterceptContext(ctx, opts)
+		if err != nil {
+			return err
+		}
+
+		if iCtx.token != nil && !iCtx.token.isPending() {
+			callOutside = true
+
+			return nil
+		}
+
+		err = invoke(iCtx.opts...)
+		if !IsPaymentRequired(err) {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
+		if err := i.handlePayment(iCtx); err != nil {
+			return err
+		}
+
+		callOutside = true
+		paymentHandled = true
+
+		return nil
+	})
+	if err != nil || !callOutside {
+		return err
 	}
 
-	// Find out if we need to pay for a new token or perhaps resume
-	// a previously aborted payment.
-	err = i.handlePayment(iCtx)
+	// This is either the first call with an existing paid token or
+	// the retry after the serialized payment path. Both can run
+	// without the lock.
+	err = invoke(iCtx.opts...)
+	if paymentHandled || !IsPaymentRequired(err) {
+		return err
+	}
+
+	// Reload a rejected paid token under the lock in case another
+	// store user updated it while the transport call was in flight.
+	err = i.withPaymentLock(func() error {
+		if err := ctx.Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
+		if err := i.refreshInterceptContext(iCtx, opts); err != nil {
+			return err
+		}
+
+		return i.handlePayment(iCtx)
+	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// Execute the same request again, now with the L402 token added
-	// as an RPC credential.
-	return streamer(ctx, desc, cc, method, iCtx.opts...)
+	return invoke(iCtx.opts...)
+}
+
+// withPaymentLock executes a function while holding the payment lock.
+func (i *ClientInterceptor) withPaymentLock(fn func() error) error {
+	i.paymentLock.Lock()
+	defer i.paymentLock.Unlock()
+
+	return fn()
 }
 
 // newInterceptContext creates the initial intercept context that can capture
 // metadata from the server and sends the local token to the server if one
 // already exists.
+//
+// NOTE: The caller must hold the payment lock.
 func (i *ClientInterceptor) newInterceptContext(ctx context.Context,
 	opts []grpc.CallOption) (*interceptContext, error) {
 
 	iCtx := &interceptContext{
 		mainCtx:  ctx,
-		opts:     opts,
+		opts:     append([]grpc.CallOption(nil), opts...),
 		metadata: &metadata.MD{},
 	}
 
@@ -256,8 +305,38 @@ func (i *ClientInterceptor) newInterceptContext(ctx context.Context,
 	return iCtx, nil
 }
 
+// refreshInterceptContext reloads the token after a payment challenge and
+// resets the call options before payment handling adds current credentials.
+//
+// NOTE: The caller must hold the payment lock.
+func (i *ClientInterceptor) refreshInterceptContext(iCtx *interceptContext,
+	opts []grpc.CallOption) error {
+
+	token, err := i.store.CurrentToken()
+	switch {
+	case err == ErrNoToken:
+		token = nil
+
+	case err != nil:
+		log.Errorf("Failed to get token from store: %v", err)
+		return fmt.Errorf("getting token from store failed: %v", err)
+	}
+
+	iCtx.token = token
+
+	// Restore only caller options. This drops stale L402
+	// credentials. The internal trailer is no longer needed because
+	// the final retry is returned directly without handling another
+	// challenge.
+	iCtx.opts = append([]grpc.CallOption(nil), opts...)
+
+	return nil
+}
+
 // handlePayment tries to obtain a valid token by either tracking the payment
 // status of a pending token or paying for a new one.
+//
+// NOTE: The caller must hold the payment lock.
 func (i *ClientInterceptor) handlePayment(iCtx *interceptContext) error {
 	switch {
 	// Resume/track a pending payment if it was interrupted for some reason.
@@ -333,6 +412,8 @@ func (i *ClientInterceptor) addL402Credentials(iCtx *interceptContext) error {
 // payL402Token reads the payment challenge from the response metadata and tries
 // to pay the invoice encoded in them, returning a paid L402 token if
 // successful.
+//
+// NOTE: The caller must hold the payment lock.
 func (i *ClientInterceptor) payL402Token(ctx context.Context, md *metadata.MD) (
 	*Token, error) {
 
@@ -418,6 +499,8 @@ func (i *ClientInterceptor) payL402Token(ctx context.Context, md *metadata.MD) (
 
 // trackPayment tries to resume a pending payment by tracking its state and
 // waiting for a conclusive result.
+//
+// NOTE: The caller must hold the payment lock.
 func (i *ClientInterceptor) trackPayment(ctx context.Context, token *Token) error {
 	// Lookup state of the payment.
 	paymentStateCtx, cancel := context.WithCancel(ctx)

--- a/l402/client_interceptor_test.go
+++ b/l402/client_interceptor_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gopkg.in/macaroon.v2"
 )
@@ -37,9 +40,16 @@ type interceptTestCase struct {
 
 type mockStore struct {
 	token *Token
+
+	// currentTokenFn overrides CurrentToken when set.
+	currentTokenFn func() (*Token, error)
 }
 
 func (s *mockStore) CurrentToken() (*Token, error) {
+	if s.currentTokenFn != nil {
+		return s.currentTokenFn()
+	}
+
 	if s.token == nil {
 		return nil, ErrNoToken
 	}
@@ -58,6 +68,133 @@ func (s *mockStore) StoreToken(token *Token) error {
 func (s *mockStore) RemovePendingToken() error {
 	s.token = nil
 	return nil
+}
+
+// interceptorTestHarness provides shared L402 state and transport behavior for
+// interceptor concurrency tests.
+type interceptorTestHarness struct {
+	// lnd provides payment and tracking test channels.
+	lnd *test.LndMockServices
+
+	// store holds the token shared by concurrent calls.
+	store *mockStore
+
+	// interceptor is the client interceptor under test.
+	interceptor *ClientInterceptor
+
+	// authenticatedCalls counts transports with L402 credentials.
+	authenticatedCalls atomic.Int32
+
+	// unauthenticatedCalls counts transports without L402 credentials.
+	unauthenticatedCalls atomic.Int32
+
+	// onAuthenticated runs during authenticated transport calls.
+	onAuthenticated func(context.Context, []grpc.CallOption) error
+
+	// onUnauthenticated runs during unauthenticated transport calls.
+	onUnauthenticated func(context.Context, []grpc.CallOption) error
+}
+
+// interceptorTestStream is a client stream used to identify individual stream
+// establishment attempts.
+type interceptorTestStream struct {
+	// ClientStream supplies the stream methods that these tests don't call.
+	grpc.ClientStream
+}
+
+// newInterceptorTestHarness creates an interceptor test harness with the given
+// initial token.
+func newInterceptorTestHarness(token *Token) *interceptorTestHarness {
+	lnd := test.NewMockLnd()
+	store := &mockStore{token: token}
+
+	return &interceptorTestHarness{
+		lnd:   lnd,
+		store: store,
+		interceptor: NewInterceptor(
+			&lnd.LndServices, store, testTimeout,
+			DefaultMaxCostSats, DefaultMaxRoutingFeeSats, false,
+		),
+	}
+}
+
+// transport simulates an Aperture transport and runs the configured hook for
+// authenticated or unauthenticated calls.
+func (h *interceptorTestHarness) transport(ctx context.Context,
+	opts ...grpc.CallOption) error {
+
+	md, authenticated, err := requestMetadata(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	var hook func(context.Context, []grpc.CallOption) error
+	if authenticated {
+		if md["macaroon"] == "" {
+			return errors.New("empty L402 credential")
+		}
+
+		h.authenticatedCalls.Add(1)
+		hook = h.onAuthenticated
+	} else {
+		h.unauthenticatedCalls.Add(1)
+		hook = h.onUnauthenticated
+	}
+
+	if hook != nil {
+		err = hook(ctx, opts)
+	}
+	if err != nil && !IsPaymentRequired(err) {
+		return err
+	}
+	if authenticated && err == nil {
+		return nil
+	}
+
+	setAuthHeaders(opts, makeAuthHeaders(testMacBytes, true))
+
+	return status.Error(GRPCErrCode, GRPCErrMessage)
+}
+
+// call invokes the unary or stream interceptor through the test transport.
+func (h *interceptorTestHarness) call(ctx context.Context, stream bool,
+	opts ...grpc.CallOption) error {
+
+	if stream {
+		_, err := h.interceptor.StreamInterceptor(
+			ctx, nil, nil, "test",
+			func(ctx context.Context, _ *grpc.StreamDesc,
+				_ *grpc.ClientConn, _ string,
+				opts ...grpc.CallOption) (
+				grpc.ClientStream, error) {
+
+				return nil, h.transport(ctx, opts...)
+			}, opts...,
+		)
+
+		return err
+	}
+
+	return h.interceptor.UnaryInterceptor(
+		ctx, "test", nil, nil, nil,
+		func(ctx context.Context, _ string, _, _ interface{},
+			_ *grpc.ClientConn, opts ...grpc.CallOption) error {
+
+			return h.transport(ctx, opts...)
+		}, opts...,
+	)
+}
+
+// start invokes a test interceptor call asynchronously.
+func (h *interceptorTestHarness) start(ctx context.Context,
+	stream bool) <-chan error {
+
+	callErr := make(chan error, 1)
+	go func() {
+		callErr <- h.call(ctx, stream)
+	}()
+
+	return callErr
 }
 
 var (
@@ -328,6 +465,598 @@ func TestStreamInterceptor(t *testing.T) {
 	}
 }
 
+// TestInterceptorConcurrentPaidCalls verifies that unary calls and stream
+// establishment are not serialized when the store contains a paid token.
+func TestInterceptorConcurrentPaidCalls(t *testing.T) {
+	testCases := []struct {
+		name   string
+		stream bool
+	}{
+		{
+			name: "unary",
+		},
+		{
+			name:   "stream",
+			stream: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := newInterceptorTestHarness(
+				makeToken(&paidPreimage),
+			)
+			callStarted := make(chan struct{}, 2)
+			releaseCalls := make(chan struct{})
+			release := sync.OnceFunc(func() {
+				close(releaseCalls)
+			})
+			t.Cleanup(release)
+
+			h.onAuthenticated = func(context.Context,
+				[]grpc.CallOption) error {
+
+				callStarted <- struct{}{}
+				<-releaseCalls
+
+				return nil
+			}
+
+			callErrs := []<-chan error{
+				h.start(t.Context(), testCase.stream),
+				h.start(t.Context(), testCase.stream),
+			}
+
+			// Both transports must start before either is
+			// released. A transport call holding the payment lock
+			// would deadlock here.
+			for range 2 {
+				receiveTestValue(
+					t, callStarted, "concurrent call",
+				)
+			}
+			release()
+
+			for _, callErr := range callErrs {
+				err := receiveTestValue(
+					t, callErr, "call result",
+				)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestInterceptorConcurrentPayment verifies that a unary call and stream share
+// one new or pending token transition without requesting redundant challenges.
+func TestInterceptorConcurrentPayment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		preimage *lntypes.Preimage
+	}{
+		{
+			name: "new payment",
+		},
+		{
+			name:     "pending payment",
+			preimage: &zeroPreimage,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := newInterceptorTestHarness(
+				makeToken(testCase.preimage),
+			)
+
+			unauthenticatedCall := make(chan struct{}, 2)
+			releaseInitialCall := make(chan struct{})
+			release := sync.OnceFunc(func() {
+				close(releaseInitialCall)
+			})
+			t.Cleanup(release)
+			h.onUnauthenticated = func(context.Context,
+				[]grpc.CallOption) error {
+
+				unauthenticatedCall <- struct{}{}
+				<-releaseInitialCall
+
+				return nil
+			}
+
+			firstErr := h.start(t.Context(), false)
+
+			// Block the first unauthenticated transport before it
+			// returns the challenge, then start the stream
+			// concurrently.
+			receiveTestValue(
+				t, unauthenticatedCall,
+				"initial unauthenticated call",
+			)
+
+			// The initial unauthenticated transport must retain
+			// the payment lock. This prevents another call from
+			// obtaining a redundant challenge before the token
+			// transition completes.
+			if h.interceptor.paymentLock.TryLock() {
+				h.interceptor.paymentLock.Unlock()
+				t.Fatal(
+					"unauthenticated transport " +
+						"did not hold payment lock",
+				)
+			}
+
+			secondErr := h.start(t.Context(), true)
+			release()
+
+			finishPayment := paymentFinisher(
+				t, h.lnd, testCase.preimage != nil,
+			)
+			finishPayment()
+
+			for _, callErr := range []<-chan error{
+				firstErr, secondErr,
+			} {
+				err := receiveTestValue(
+					t, callErr, "call result",
+				)
+				require.NoError(t, err)
+			}
+
+			// The queued stream must reuse the token instead of
+			// obtaining a second challenge and initiating another
+			// payment.
+			require.EqualValues(
+				t, 1, h.unauthenticatedCalls.Load(),
+			)
+			require.EqualValues(
+				t, 2, h.authenticatedCalls.Load(),
+			)
+			token, err := h.store.CurrentToken()
+			require.NoError(t, err)
+			require.Equal(t, paidPreimage, token.Preimage)
+			require.False(t, token.isPending())
+			require.NoError(t, h.lnd.IsDone())
+		})
+	}
+}
+
+// TestInterceptorConcurrentPaidTokenRefresh verifies that concurrent calls
+// rejected with a paid token share one replacement payment after it is removed.
+func TestInterceptorConcurrentPaidTokenRefresh(t *testing.T) {
+	// Give the rejected and replacement tokens distinct credentials
+	// so stale retries cannot be accepted as successful refreshes.
+	oldPreimage := lntypes.Preimage{9, 8, 7, 6, 5}
+	oldToken := makeToken(&oldPreimage)
+	h := newInterceptorTestHarness(oldToken)
+
+	credentialMacaroon := func(token *Token) string {
+		mac, err := token.PaidMacaroon()
+		require.NoError(t, err)
+
+		return hex.EncodeToString(serializeMac(mac))
+	}
+	oldCredential := credentialMacaroon(oldToken)
+	replacementCredential := credentialMacaroon(
+		makeToken(&paidPreimage),
+	)
+	require.NotEqual(t, oldCredential, replacementCredential)
+
+	initialCalls := make(chan struct{}, 2)
+	releaseInitialCalls := make(chan struct{})
+	release := sync.OnceFunc(func() {
+		close(releaseInitialCalls)
+	})
+	t.Cleanup(release)
+
+	var (
+		calls            atomic.Int32
+		credentials      [4]string
+		credentialErrors [4]error
+	)
+	h.onAuthenticated = func(ctx context.Context,
+		opts []grpc.CallOption) error {
+
+		call := calls.Add(1)
+		if call > int32(len(credentials)) {
+			return fmt.Errorf(
+				"unexpected authenticated call %d", call,
+			)
+		}
+
+		md, authenticated, err := requestMetadata(ctx, opts)
+		idx := int(call - 1)
+		if err == nil {
+			if !authenticated {
+				err = errors.New("missing L402 credential")
+			} else {
+				credentials[idx] = md["macaroon"]
+			}
+		}
+		credentialErrors[idx] = err
+
+		if call > 2 {
+			return nil
+		}
+
+		initialCalls <- struct{}{}
+		<-releaseInitialCalls
+
+		return status.Error(GRPCErrCode, GRPCErrMessage)
+	}
+
+	callErrs := []<-chan error{
+		h.start(t.Context(), false),
+		h.start(t.Context(), true),
+	}
+
+	// Ensure both calls loaded the old token before simulating its removal.
+	for range 2 {
+		receiveTestValue(t, initialCalls, "rejected paid-token call")
+	}
+	if !h.interceptor.paymentLock.TryLock() {
+		t.Fatal("paid-token transports retained payment lock")
+	}
+	h.store.token = nil
+	h.interceptor.paymentLock.Unlock()
+	release()
+
+	// The first refresh pays while the second waits, then reuses its
+	// token.
+	payment := receiveTestPaymentRequest(
+		t, h.lnd, "replacement token payment",
+	)
+	sendTestValue(
+		t, payment.Done, lndclient.PaymentResult{
+			Preimage: paidPreimage,
+			PaidAmt:  123,
+			PaidFee:  345,
+		}, "replacement payment result",
+	)
+
+	for _, callErr := range callErrs {
+		err := receiveTestValue(t, callErr, "refreshed call result")
+		require.NoError(t, err)
+	}
+
+	// Both initial attempts must use the rejected credential, while both
+	// retries must use the single replacement purchased above.
+	expectedCredentials := [4]string{
+		oldCredential, oldCredential,
+		replacementCredential, replacementCredential,
+	}
+	for idx, expectedCredential := range expectedCredentials {
+		require.NoError(t, credentialErrors[idx])
+		require.Equal(t, expectedCredential, credentials[idx])
+	}
+
+	require.EqualValues(t, 4, h.authenticatedCalls.Load())
+	require.EqualValues(t, 0, h.unauthenticatedCalls.Load())
+	token, err := h.store.CurrentToken()
+	require.NoError(t, err)
+	require.Equal(t, paidPreimage, token.Preimage)
+	require.False(t, token.isPending())
+	require.NoError(t, h.lnd.IsDone())
+}
+
+// TestInterceptorPaymentErrorUnlocks verifies that a failed payment releases
+// the lock so a queued caller can resume the persisted pending payment.
+func TestInterceptorPaymentErrorUnlocks(t *testing.T) {
+	h := newInterceptorTestHarness(nil)
+	firstErr := h.start(t.Context(), false)
+
+	payment := receiveTestPaymentRequest(t, h.lnd, "token payment")
+
+	secondErr := h.start(t.Context(), true)
+
+	// Fail the first payment after the second call starts. The
+	// pending token remains available for the queued call to track.
+	paymentErr := errors.New("payment failed")
+	payment.Done <- lndclient.PaymentResult{Err: paymentErr}
+	err := receiveTestValue(t, firstErr, "failed payment result")
+	require.ErrorIs(t, err, paymentErr)
+
+	track := receiveTestTrackRequest(t, h.lnd, "payment tracking")
+	sendTestValue(
+		t, track.Updates, lndclient.PaymentStatus{
+			State:    lnrpc.Payment_SUCCEEDED,
+			Preimage: paidPreimage,
+		}, "tracked payment result",
+	)
+
+	err = receiveTestValue(t, secondErr, "queued call")
+	require.NoError(t, err)
+	require.NoError(t, h.lnd.IsDone())
+}
+
+// TestInterceptorCanceledInitialChallenge verifies that cancellation after an
+// initial challenge prevents token storage and payment.
+func TestInterceptorCanceledInitialChallenge(t *testing.T) {
+	h := newInterceptorTestHarness(nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	h.onUnauthenticated = func(context.Context, []grpc.CallOption) error {
+		// Cancel before returning the challenge to exercise the guard
+		// between challenge receipt and payment handling.
+		cancel()
+
+		return nil
+	}
+
+	callErr := h.start(ctx, false)
+
+	// A regression in the cancellation guard must report the
+	// unexpected LND request instead of blocking the test on the
+	// mock's unbuffered channel.
+	err := receiveCallWithoutPayment(t, callErr, h.lnd, "canceled call")
+
+	require.Equal(t, codes.Canceled, status.Code(err))
+	_, err = h.store.CurrentToken()
+	require.ErrorIs(t, err, ErrNoToken)
+	require.NoError(t, h.lnd.IsDone())
+}
+
+// TestInterceptorCanceledPaymentWaiter verifies that a caller canceled while
+// waiting for payment serialization cannot update the store or call lnd.
+func TestInterceptorCanceledPaymentWaiter(t *testing.T) {
+	h := newInterceptorTestHarness(makeToken(&paidPreimage))
+	callStarted := make(chan struct{})
+	releaseCall := make(chan struct{})
+	release := sync.OnceFunc(func() {
+		close(releaseCall)
+	})
+	t.Cleanup(release)
+	h.onAuthenticated = func(context.Context, []grpc.CallOption) error {
+		close(callStarted)
+		<-releaseCall
+
+		return status.Error(GRPCErrCode, GRPCErrMessage)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	callErr := h.start(ctx, false)
+
+	receiveTestValue(t, callStarted, "authenticated call")
+	if !h.interceptor.paymentLock.TryLock() {
+		t.Fatal("authenticated transport retained payment lock")
+	}
+	h.store.token = nil
+	release()
+	cancel()
+	h.interceptor.paymentLock.Unlock()
+
+	// The context check after lock acquisition must run before the
+	// refreshed empty store can trigger payment handling.
+	err := receiveCallWithoutPayment(t, callErr, h.lnd, "canceled call")
+	require.Equal(t, codes.Canceled, status.Code(err))
+	_, err = h.store.CurrentToken()
+	require.ErrorIs(t, err, ErrNoToken)
+	require.NoError(t, h.lnd.IsDone())
+}
+
+// TestInterceptorRefreshesPaidToken verifies that payment retry reloads the
+// token, preserves caller options and replaces the old L402 credentials.
+func TestInterceptorRefreshesPaidToken(t *testing.T) {
+	secondPreimage := lntypes.Preimage{5, 4, 3, 2, 1}
+	tokens := []*Token{
+		makeToken(&paidPreimage),
+		makeToken(&secondPreimage),
+	}
+	h := newInterceptorTestHarness(tokens[0])
+	callerMacaroon, err := makeToken(
+		&lntypes.Preimage{9, 8, 7, 6, 5},
+	).PaidMacaroon()
+	require.NoError(t, err)
+	callerCredential := NewMacaroonCredential(callerMacaroon, false)
+
+	var reads int
+	h.store.currentTokenFn = func() (*Token, error) {
+		if reads == len(tokens) {
+			return nil, errors.New("unexpected token read")
+		}
+
+		token := tokens[reads]
+		reads++
+
+		return token, nil
+	}
+
+	var macaroons []string
+	h.onAuthenticated = func(ctx context.Context,
+		opts []grpc.CallOption) error {
+
+		md, ok, err := requestMetadata(ctx, opts)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		var (
+			credentialCount int
+			waitForReady    bool
+		)
+		for _, opt := range opts {
+			switch opt := opt.(type) {
+			case grpc.PerRPCCredsCallOption:
+				credentialCount++
+
+			case grpc.FailFastCallOption:
+				waitForReady = !opt.FailFast
+			}
+		}
+		// The caller credential must remain while exactly one
+		// current L402 credential stays last and therefore
+		// effective.
+		require.Equal(t, 2, credentialCount)
+		require.True(t, waitForReady)
+		macaroons = append(macaroons, md["macaroon"])
+
+		if len(macaroons) == 1 {
+			return status.Error(GRPCErrCode, GRPCErrMessage)
+		}
+
+		return nil
+	}
+
+	err = h.call(
+		t.Context(), false,
+		grpc.PerRPCCredentials(callerCredential),
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+	require.Len(t, macaroons, 2)
+	require.NotEqual(t, macaroons[0], macaroons[1])
+	require.Equal(t, 2, reads)
+}
+
+// TestInterceptorRefreshError verifies that a failed token reload aborts the
+// retry and returns the store error without calling the transport again.
+func TestInterceptorRefreshError(t *testing.T) {
+	storeErr := errors.New("store unavailable")
+	h := newInterceptorTestHarness(makeToken(&paidPreimage))
+	var reads int
+	h.store.currentTokenFn = func() (*Token, error) {
+		reads++
+		if reads == 1 {
+			return makeToken(&paidPreimage), nil
+		}
+
+		return nil, storeErr
+	}
+	h.onAuthenticated = func(context.Context, []grpc.CallOption) error {
+		return status.Error(GRPCErrCode, GRPCErrMessage)
+	}
+
+	err := h.call(t.Context(), false)
+	require.ErrorContains(t, err, storeErr.Error())
+	require.Equal(t, 2, reads)
+	require.EqualValues(t, 1, h.authenticatedCalls.Load())
+}
+
+// TestInterceptorPaymentLockPanic verifies that panic unwinding releases the
+// payment lock for later calls.
+func TestInterceptorPaymentLockPanic(t *testing.T) {
+	panicErr := errors.New("store panic")
+	h := newInterceptorTestHarness(makeToken(&paidPreimage))
+	var reads int
+	h.store.currentTokenFn = func() (*Token, error) {
+		reads++
+		if reads == 1 {
+			panic(panicErr)
+		}
+
+		return makeToken(&paidPreimage), nil
+	}
+
+	func() {
+		defer func() {
+			require.Equal(t, panicErr, recover())
+		}()
+
+		_ = h.call(t.Context(), false)
+	}()
+
+	callErr := h.start(t.Context(), false)
+	err := receiveTestValue(t, callErr, "call after panic")
+	require.NoError(t, err)
+}
+
+// TestInterceptorStreamRetryResult verifies that a stream retry returns only
+// the final successful stream and clears an earlier stream on payment failure.
+func TestInterceptorStreamRetryResult(t *testing.T) {
+	paymentErr := errors.New("payment failed")
+	testCases := []struct {
+		name          string
+		paymentErr    error
+		expectSuccess bool
+	}{
+		{
+			name:          "successful retry",
+			expectSuccess: true,
+		},
+		{
+			name:       "payment failure",
+			paymentErr: paymentErr,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := newInterceptorTestHarness(nil)
+			initialStream := &interceptorTestStream{}
+			finalStream := &interceptorTestStream{}
+			var calls int
+
+			streamer := func(_ context.Context, _ *grpc.StreamDesc,
+				_ *grpc.ClientConn, _ string,
+				opts ...grpc.CallOption) (
+				grpc.ClientStream, error) {
+
+				calls++
+				if calls == 1 {
+					// Deliberately return a non-nil
+					// rejected stream to ensure it cannot
+					// escape as the result.
+					setAuthHeaders(
+						opts,
+						makeAuthHeaders(
+							testMacBytes, true,
+						),
+					)
+
+					return initialStream, status.Error(
+						GRPCErrCode, GRPCErrMessage,
+					)
+				}
+
+				return finalStream, nil
+			}
+
+			resultChan := make(chan struct {
+				stream grpc.ClientStream
+				err    error
+			}, 1)
+			go func() {
+				stream, err := h.interceptor.StreamInterceptor(
+					t.Context(), nil, nil, "test", streamer,
+				)
+				resultChan <- struct {
+					stream grpc.ClientStream
+					err    error
+				}{
+					stream: stream,
+					err:    err,
+				}
+			}()
+
+			payment := receiveTestPaymentRequest(
+				t, h.lnd, "token payment",
+			)
+			sendTestValue(
+				t, payment.Done, lndclient.PaymentResult{
+					Err:      testCase.paymentErr,
+					Preimage: paidPreimage,
+					PaidAmt:  123,
+					PaidFee:  345,
+				}, "payment result",
+			)
+
+			result := receiveTestValue(
+				t, resultChan, "stream result",
+			)
+			if testCase.expectSuccess {
+				require.NoError(t, result.err)
+				require.Same(t, finalStream, result.stream)
+				require.Equal(t, 2, calls)
+
+				return
+			}
+
+			require.ErrorIs(t, result.err, paymentErr)
+			require.Nil(t, result.stream)
+			require.Equal(t, 1, calls)
+		})
+	}
+}
+
 func testInterceptor(t *testing.T, tc interceptTestCase, addL402 bool,
 	intercept func() error) {
 
@@ -411,6 +1140,179 @@ func testInterceptor(t *testing.T, tc interceptTestCase, addL402 bool,
 		require.Greater(t, len(callMD["macaroon"]), len(testMacHex))
 	}
 	require.Equal(t, tc.expectBackendCalls, numBackendCalls)
+}
+
+// paymentFinisher waits for a new or pending payment request and returns a
+// function that completes it successfully.
+func paymentFinisher(t *testing.T, lnd *test.LndMockServices,
+	pending bool) func() {
+
+	t.Helper()
+
+	if pending {
+		track := receiveTestTrackRequest(t, lnd, "payment tracking")
+
+		return func() {
+			sendTestValue(
+				t, track.Updates, lndclient.PaymentStatus{
+					State:    lnrpc.Payment_SUCCEEDED,
+					Preimage: paidPreimage,
+				}, "tracked payment result",
+			)
+		}
+	}
+
+	payment := receiveTestPaymentRequest(t, lnd, "token payment")
+
+	return func() {
+		sendTestValue(
+			t, payment.Done, lndclient.PaymentResult{
+				Preimage: paidPreimage,
+				PaidAmt:  123,
+				PaidFee:  345,
+			}, "payment result",
+		)
+	}
+}
+
+// receiveTestPaymentRequest receives a payment request and fails if tracking
+// was requested instead or the operation times out.
+func receiveTestPaymentRequest(t *testing.T, lnd *test.LndMockServices,
+	name string) test.PaymentChannelMessage {
+
+	t.Helper()
+
+	select {
+	case payment := <-lnd.SendPaymentChannel:
+		return payment
+
+	case track := <-lnd.TrackPaymentChannel:
+		// Release the synchronous mock before failing the test.
+		close(track.Errors)
+		t.Fatalf("received payment tracking while waiting for %s", name)
+
+	case <-time.After(testTimeout):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+
+	return test.PaymentChannelMessage{}
+}
+
+// receiveTestTrackRequest receives a tracking request and fails if a payment
+// was requested instead or the operation times out.
+func receiveTestTrackRequest(t *testing.T, lnd *test.LndMockServices,
+	name string) test.TrackPaymentMessage {
+
+	t.Helper()
+
+	select {
+	case track := <-lnd.TrackPaymentChannel:
+		return track
+
+	case payment := <-lnd.SendPaymentChannel:
+		// Release the synchronous mock before failing the test.
+		payment.Done <- lndclient.PaymentResult{
+			Err: errors.New("unexpected token payment"),
+		}
+		t.Fatalf("received token payment while waiting for %s", name)
+
+	case <-time.After(testTimeout):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+
+	return test.TrackPaymentMessage{}
+}
+
+// receiveCallWithoutPayment receives a call result and fails if the call tries
+// to pay or track a token before returning.
+func receiveCallWithoutPayment(t *testing.T, callErr <-chan error,
+	lnd *test.LndMockServices, name string) error {
+
+	t.Helper()
+
+	select {
+	case err := <-callErr:
+		return err
+
+	case payment := <-lnd.SendPaymentChannel:
+		// Release the synchronous mock before failing the test.
+		payment.Done <- lndclient.PaymentResult{
+			Err: errors.New("unexpected token payment"),
+		}
+		t.Fatalf("received token payment while waiting for %s", name)
+
+	case track := <-lnd.TrackPaymentChannel:
+		// Release the synchronous mock before failing the test.
+		close(track.Errors)
+		t.Fatalf("received payment tracking while waiting for %s", name)
+
+	case <-time.After(testTimeout):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+
+	return nil
+}
+
+// sendTestValue sends a test value or fails when the operation times out.
+func sendTestValue[T any](t *testing.T, values chan<- T, value T,
+	name string) {
+
+	t.Helper()
+
+	select {
+	case values <- value:
+
+	case <-time.After(testTimeout):
+		t.Fatalf("timed out sending %s", name)
+	}
+}
+
+// receiveTestValue receives a test value or fails when the operation times
+// out.
+func receiveTestValue[T any](t *testing.T, values <-chan T, name string) T {
+	t.Helper()
+
+	select {
+	case value := <-values:
+		return value
+
+	case <-time.After(testTimeout):
+		t.Fatalf("timed out waiting for %s", name)
+		var zero T
+
+		return zero
+	}
+}
+
+// requestMetadata returns the request metadata from the effective per-RPC
+// credential and reports whether credentials were found. The last credential
+// option wins, matching gRPC call option processing.
+func requestMetadata(ctx context.Context, opts []grpc.CallOption) (
+	map[string]string, bool, error) {
+
+	for idx := len(opts) - 1; idx >= 0; idx-- {
+		opt := opts[idx]
+		creds, ok := opt.(grpc.PerRPCCredsCallOption)
+		if !ok {
+			continue
+		}
+
+		md, err := creds.Creds.GetRequestMetadata(ctx)
+
+		return md, true, err
+	}
+
+	return nil, false, nil
+}
+
+// setAuthHeaders adds a payment challenge to every trailer call option.
+func setAuthHeaders(opts []grpc.CallOption, authHeaders []string) {
+	for _, opt := range opts {
+		trailer, ok := opt.(grpc.TrailerCallOption)
+		if ok {
+			trailer.TrailerAddr.Set(AuthHeader, authHeaders...)
+		}
+	}
 }
 
 func makeToken(preimage *lntypes.Preimage) *Token {


### PR DESCRIPTION
Keep unauthenticated token acquisition serialized, but release the payment lock before calls with a paid token. This prevents a slow authenticated request from blocking unrelated calls.

Recheck rejected paid-token calls under the payment lock so concurrent callers share a single token transition without risking duplicate payments.